### PR TITLE
Fix buffer bug for multipolygons

### DIFF
--- a/tests/test_chips.py
+++ b/tests/test_chips.py
@@ -1,0 +1,20 @@
+import math
+import pytest
+from verdesat.ingestion.chips import compute_buffer
+
+
+def test_compute_buffer_multipolygon():
+    poly = {
+        "type": "MultiPolygon",
+        "coordinates": [
+            [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+            [[[4, 0], [4, 1], [5, 1], [5, 0], [4, 0]]],
+        ],
+    }
+    result = compute_buffer([{"geometry": poly}], 0, 10)
+    mean_lat = 0.5
+    width_m = 5 * 111320.0 * math.cos(math.radians(mean_lat))
+    height_m = 1 * 111320.0
+    extent_max = max(abs(width_m), abs(height_m))
+    expected = extent_max * 0.1
+    assert result == pytest.approx(expected)

--- a/verdesat/ingestion/chips.py
+++ b/verdesat/ingestion/chips.py
@@ -22,12 +22,18 @@ def compute_buffer(
     coords = []
     for feat in features:
         geom = feat.get("geometry", {})
+        geom_type = geom.get("type")
         coords_list = geom.get("coordinates", [])
-        # Handle Polygon or MultiPolygon
-        rings = coords_list[0] if geom.get("type") == "MultiPolygon" else coords_list
-        if rings and isinstance(rings[0], list):
-            for x, y in rings[0]:
-                coords.append((x, y))
+        if geom_type == "Polygon":
+            polygons = [coords_list]
+        elif geom_type == "MultiPolygon":
+            polygons = coords_list
+        else:
+            polygons = []
+        for poly in polygons:
+            if poly and isinstance(poly[0], list):
+                for x, y in poly[0]:
+                    coords.append((x, y))
     if not coords:
         return buffer
     xs, ys = zip(*coords)


### PR DESCRIPTION
## Summary
- fix `compute_buffer` to include all polygons when computing buffer distance
- add regression test for multipolygon buffering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6c0c80108321bac1604d1148cf0f