### PR TITLE
Introduce ingestion backend abstraction

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -386,9 +386,9 @@ def _dummy_ee_manager(monkeypatch):
                 ]
             }
 
-    # Monkeypatch the ee_manager used in DataIngestor
+    # Monkeypatch the ee_manager used in EarthEngineIngestor
     monkeypatch.setattr(
-        "verdesat.ingestion.dataingestor.ee_manager.get_image_collection",
+        "verdesat.ingestion.earthengine_ingestor.ee_manager.get_image_collection",
         lambda *args, **kwargs: FakeFC([None]),
     )
     return FakeFC

--- a/tests/test_dataingestor.py
+++ b/tests/test_dataingestor.py
@@ -1,31 +1,30 @@
-"""
-Tests for DataIngestor time‑series download helper.
-"""
+"""Tests for EarthEngineIngestor time‑series download helper."""
 
 # pylint: disable=W0621,W0613,C0103,missing-class-docstring,missing-function-docstring,line-too-long
 
 
 import pandas as pd
 
-from verdesat.ingestion.dataingestor import DataIngestor
+from verdesat.ingestion.earthengine_ingestor import EarthEngineIngestor
+from verdesat.visualization._chips_config import ChipsConfig
 
 
 def test_download_timeseries_no_aggregation(
     dummy_aoi, dummy_sensor, _dummy_ee_manager, monkeypatch
 ):
     """
-    Test that DataIngestor.download_timeseries returns a DataFrame with correct columns
+    Test that EarthEngineIngestor.download_timeseries returns a DataFrame with correct columns
     for one daily chunk, without aggregation (freq=None).
     """
     # Stub out chunked retrieval to return a known DataFrame
     monkeypatch.setattr(
-        DataIngestor,
+        EarthEngineIngestor,
         "_chunked_timeseries",
         lambda self, aoi, start_date, end_date, scale, index, chunk_freq: pd.DataFrame(
             [{"id": 1, "date": "2020-01-01", f"mean_{index}": 0.5}]
         ),
     )
-    di = DataIngestor(sensor=dummy_sensor)
+    di = EarthEngineIngestor(sensor=dummy_sensor)
     df = di.download_timeseries(
         dummy_aoi,
         start_date="2020-01-01",
@@ -48,7 +47,7 @@ def test_download_timeseries_with_aggregation(
     dummy_aoi, dummy_sensor, _dummy_ee_manager, monkeypatch
 ):
     """
-    Test that DataIngestor.download_timeseries with freq='M' returns a DataFrame
+    Test that EarthEngineIngestor.download_timeseries with freq='M' returns a DataFrame
     resampled to monthly (here, single month so no change).
     """
     # Stub out chunked retrieval to return a known daily DataFrame over January 2020
@@ -57,13 +56,13 @@ def test_download_timeseries_with_aggregation(
         for day in range(1, 32)
     ]
     monkeypatch.setattr(
-        DataIngestor,
+        EarthEngineIngestor,
         "_chunked_timeseries",
         lambda self, aoi, start_date, end_date, scale, index, chunk_freq: pd.DataFrame(
             raw_data
         ),
     )
-    di = DataIngestor(sensor=dummy_sensor)
+    di = EarthEngineIngestor(sensor=dummy_sensor)
     df_agg = di.download_timeseries(
         dummy_aoi,
         start_date="2020-01-01",
@@ -78,3 +77,48 @@ def test_download_timeseries_with_aggregation(
     assert list(df_agg.columns) == ["id", "date", "mean_ndvi"]
     # Date should be the month‐start or aggregated index (since only one point).
     assert pd.to_datetime(df_agg.iloc[0]["date"]).month == 1
+
+
+def test_download_chips_delegation(dummy_aoi, dummy_sensor, monkeypatch, tmp_path):
+    """EarthEngineIngestor.download_chips should delegate to ChipService."""
+
+    calls = {}
+
+    class FakeService:
+        def __init__(self, ee_manager, sensor_spec, logger=None):
+            calls["init"] = (ee_manager, sensor_spec)
+
+        def run(self, aois, config):
+            calls["run"] = (aois, config)
+
+    monkeypatch.setattr(
+        "verdesat.ingestion.earthengine_ingestor.ChipService", FakeService
+    )
+
+    di = EarthEngineIngestor(sensor=dummy_sensor)
+
+    cfg = ChipsConfig(
+        collection_id="dummy/collection",
+        start="2024-01-01",
+        end="2024-12-31",
+        period="year",
+        chip_type="ndvi",
+        scale=30,
+        buffer=0,
+        buffer_percent=None,
+        min_val=None,
+        max_val=None,
+        gamma=None,
+        percentile_low=None,
+        percentile_high=None,
+        palette=None,
+        fmt="png",
+        out_dir=str(tmp_path),
+        mask_clouds=True,
+    )
+
+    di.download_chips([dummy_aoi], cfg)
+
+    assert "init" in calls and "run" in calls
+    assert calls["run"][0] == [dummy_aoi]
+    assert calls["run"][1] is cfg

--- a/verdesat/ingestion/__init__.py
+++ b/verdesat/ingestion/__init__.py
@@ -1,0 +1,16 @@
+"""Ingestion package with backend factory."""
+
+from .base import BaseDataIngestor
+from .earthengine_ingestor import EarthEngineIngestor
+from .sensorspec import SensorSpec
+
+
+def create_ingestor(backend: str, sensor: SensorSpec, **kwargs) -> BaseDataIngestor:
+    """Factory returning an ingestor instance based on backend name."""
+    name = backend.lower()
+    if name in {"ee", "earthengine"}:
+        return EarthEngineIngestor(sensor, **kwargs)
+    raise ValueError(f"Unknown ingestor backend '{backend}'")
+
+
+__all__ = ["BaseDataIngestor", "EarthEngineIngestor", "create_ingestor"]

--- a/verdesat/ingestion/base.py
+++ b/verdesat/ingestion/base.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Abstract base class for data ingestion backends."""
+
+from abc import ABC, abstractmethod
+from typing import Literal, Optional, List
+
+import pandas as pd
+
+from verdesat.core.logger import Logger
+from verdesat.geo.aoi import AOI
+from ..visualization._chips_config import ChipsConfig
+from .sensorspec import SensorSpec
+
+
+class BaseDataIngestor(ABC):
+    """Base interface for data ingestion implementations."""
+
+    def __init__(self, sensor: SensorSpec, logger=None):
+        self.sensor = sensor
+        self.logger = logger or Logger.get_logger(__name__)
+
+    @abstractmethod
+    def download_timeseries(
+        self,
+        aoi: AOI,
+        start_date: str,
+        end_date: str,
+        scale: int,
+        index: str,
+        chunk_freq: Literal["D", "ME", "YE"] = "YE",
+        freq: Optional[Literal["D", "ME", "YE"]] = None,
+    ) -> pd.DataFrame:
+        """Download and optionally aggregate an index time series for an AOI."""
+
+    @abstractmethod
+    def download_chips(self, aois: List[AOI], config: ChipsConfig) -> None:
+        """Export image chips for the given AOIs using configuration."""
+        raise NotImplementedError

--- a/verdesat/project/project.py
+++ b/verdesat/project/project.py
@@ -5,7 +5,7 @@ from typing import List, Literal
 from verdesat.geo.aoi import AOI
 from verdesat.core.config import ConfigManager
 from verdesat.ingestion.vector_preprocessor import VectorPreprocessor
-from verdesat.ingestion.dataingestor import DataIngestor
+from verdesat.ingestion import create_ingestor
 from verdesat.ingestion.sensorspec import SensorSpec
 from verdesat.analytics.timeseries import TimeSeries
 from verdesat.visualization.visualizer import Visualizer
@@ -75,7 +75,8 @@ class VerdeSatProject:
         """
         # Instantiate ingestion components
         sensor = SensorSpec.from_collection_id(collection_id)
-        ingestor = DataIngestor(sensor)
+        backend = self.config.get("ingestor_backend", "ee")
+        ingestor = create_ingestor(backend, sensor)
         # Download and attach timeseries for each AOI
         for aoi in self.aois:
             df = ingestor.download_timeseries(


### PR DESCRIPTION
## Summary
- add BaseDataIngestor abstract class and factory
- rename DataIngestor to EarthEngineIngestor
- update CLI and project to create ingestor via factory
- connect chip export logic through EarthEngineIngestor
- add backend option to chips command

## Testing
- `black .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68780059b1188321b4198a7f85a4813f