### PR TITLE
Introduce analytics result dataclasses

### DIFF
--- a/tests/test_analytics_engine.py
+++ b/tests/test_analytics_engine.py
@@ -7,6 +7,7 @@ def test_compute_trend():
     dates = pd.date_range("2020-01-01", periods=3, freq="ME")
     df = pd.DataFrame({"id": [1, 1, 1], "date": dates, "mean_ndvi": [0.1, 0.2, 0.3]})
     ts = TimeSeries.from_dataframe(df, index="ndvi")
-    trend_df = AnalyticsEngine.compute_trend(ts)
-    assert not trend_df.empty
-    assert list(trend_df.columns) == ["id", "date", "trend"]
+    trend = AnalyticsEngine.compute_trend(ts)
+    df_trend = trend.to_dataframe()
+    assert not df_trend.empty
+    assert list(df_trend.columns) == ["id", "date", "trend"]

--- a/verdesat/analytics/__init__.py
+++ b/verdesat/analytics/__init__.py
@@ -1,0 +1,5 @@
+"""Analytics helpers and result data types."""
+
+from .results import TrendResult, StatsResult
+
+__all__ = ["TrendResult", "StatsResult"]

--- a/verdesat/analytics/engine.py
+++ b/verdesat/analytics/engine.py
@@ -10,6 +10,7 @@ import ee
 from ee import Reducer
 from .timeseries import TimeSeries
 from .trend import compute_trend as _compute_trend
+from .results import TrendResult
 
 
 class AnalyticsEngine:
@@ -67,6 +68,6 @@ class AnalyticsEngine:
         return composites
 
     @staticmethod
-    def compute_trend(ts: TimeSeries):
-        """Return a DataFrame of trend values for the TimeSeries."""
+    def compute_trend(ts: TimeSeries) -> TrendResult:
+        """Return trend values for the given TimeSeries."""
         return _compute_trend(ts.df, column=f"mean_{ts.index}")

--- a/verdesat/analytics/results.py
+++ b/verdesat/analytics/results.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Dict
+
+import pandas as pd
+
+
+@dataclass
+class TrendResult:
+    """Linear trend values for each polygon."""
+
+    df: pd.DataFrame
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Return the trend values as a DataFrame."""
+        return self.df
+
+    def to_csv(self, path: str) -> None:
+        """Write the trend values to CSV."""
+        self.df.to_csv(path, index=False)
+
+
+@dataclass
+class StatsResult:
+    """Summary statistics computed for each polygon."""
+
+    rows: List[Dict]
+
+    def to_dataframe(self) -> pd.DataFrame:
+        """Return the statistics as a DataFrame."""
+        return pd.DataFrame(self.rows)
+
+    def to_csv(self, path: str) -> None:
+        """Write the summary statistics to CSV."""
+        self.to_dataframe().to_csv(path, index=False)

--- a/verdesat/analytics/stats.py
+++ b/verdesat/analytics/stats.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import List, Dict, Optional
 from scipy.stats import theilslopes, kendalltau
 from verdesat.core.config import ConfigManager
+from .results import StatsResult
 
 
 def compute_summary_stats(
@@ -17,10 +18,8 @@ def compute_summary_stats(
     value_col: str = ConfigManager.VALUE_COL_TEMPLATE.format(
         index=ConfigManager.DEFAULT_INDEX
     ),
-) -> List[Dict]:
-    """
-    Build per‐site summary stats for your report.
-    """
+) -> StatsResult:
+    """Build per-site summary stats and return them as a :class:`StatsResult`."""
     # 1) Load and pivot
     df = pd.read_csv(timeseries_csv, parse_dates=["date"])
     stats = []
@@ -104,4 +103,4 @@ def compute_summary_stats(
             }
         )
 
-    return stats
+    return StatsResult(stats)

--- a/verdesat/analytics/trend.py
+++ b/verdesat/analytics/trend.py
@@ -2,6 +2,8 @@ import pandas as pd
 import statsmodels.api as sm
 from typing import Literal
 
+from .results import TrendResult
+
 
 from verdesat.core.config import ConfigManager
 
@@ -12,11 +14,8 @@ def compute_trend(
         index=ConfigManager.DEFAULT_INDEX
     ),
     id_col: str = "id",
-) -> pd.DataFrame:
-    """
-    Fit a linear trend to each polygon's time-series.
-    Returns a DataFrame with columns ['id','date','trend'].
-    """
+) -> TrendResult:
+    """Fit a linear trend to each polygon's time series and return a :class:`TrendResult`."""
     rows = []
     for pid, grp in df.groupby(id_col):
         # Drop missing
@@ -30,4 +29,5 @@ def compute_trend(
         fitted = model.predict(X)
         temp = pd.DataFrame({"id": pid, "date": s["date"], "trend": fitted})
         rows.append(temp)
-    return pd.concat(rows, ignore_index=True)
+    result_df = pd.concat(rows, ignore_index=True)
+    return TrendResult(result_df)

--- a/verdesat/core/cli.py
+++ b/verdesat/core/cli.py
@@ -517,9 +517,9 @@ def trend(input_csv, index_col, output):
     echo(f"Loading {input_csv}...")
     df = pd.read_csv(input_csv, parse_dates=["date"])
     echo("Computing trend...")
-    df_trend = compute_trend(df, column=index_col)
+    trend_res = compute_trend(df, column=index_col)
     echo(f"Saving trend data to {output}...")
-    df_trend.to_csv(output, index=False)
+    trend_res.to_csv(output)
     echo(f"✅  Trend data saved to {output}")
 
 

--- a/verdesat/visualization/report.py
+++ b/verdesat/visualization/report.py
@@ -34,7 +34,7 @@ def build_report(
         timeseries_csv,
         decomp_dir=decomposition_dir,
         value_col=f"mean_{index_name}",
-    )
+    ).rows
     # 3. Discover decomposition images: files named like "1_decomposition.png"
     decomp_pattern = r"(?P<id>\d+)_decomposition\.png"
     decomp_images = {}


### PR DESCRIPTION
## Summary
- create `TrendResult` and `StatsResult` dataclasses
- refactor trend and stats functions to return typed results
- adjust CLI and report generation for new APIs
- update AnalyticsEngine and associated tests

## Testing
- `black . && flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879349f6a3c8321af5cbd3f82d6696f