### PR TITLE
Add storage adapter and remote chip export

### DIFF
--- a/tests/test_chips_exporter.py
+++ b/tests/test_chips_exporter.py
@@ -42,7 +42,7 @@ def test_export_one_thumbnail_png(tmp_export_dir, dummy_img, dummy_feat, monkeyp
         "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1]]]
     }
 
-    exporter.export_one(
+    dest = exporter.export_one(
         img=dummy_img,
         aoi=dummy_aoi,
         date_str="2024-01-01",
@@ -57,6 +57,7 @@ def test_export_one_thumbnail_png(tmp_export_dir, dummy_img, dummy_feat, monkeyp
     )
 
     out_path = tmp_export_dir / "RGB_1_2024-01-01.png"
+    assert dest == str(out_path)
     assert out_path.exists()
     assert out_path.read_bytes() == b"PNGDATA"
 
@@ -115,7 +116,7 @@ def test_export_one_thumbnail_geotiff_cog(
         "coordinates": [[[0, 0], [1, 0], [1, 1], [0, 1]]]
     }
 
-    exporter.export_one(
+    dest = exporter.export_one(
         img=dummy_img,
         aoi=dummy_aoi,
         date_str="2024-01-01",
@@ -130,6 +131,7 @@ def test_export_one_thumbnail_geotiff_cog(
     )
 
     out_path = tmp_export_dir / "NDVI_1_2024-01-01.tiff"
+    assert dest == str(out_path)
     assert out_path.exists()
     assert fake_rasterio.open.called
 

--- a/tests/test_dataingestor.py
+++ b/tests/test_dataingestor.py
@@ -88,8 +88,8 @@ def test_download_chips_delegation(dummy_aoi, dummy_sensor, monkeypatch, tmp_pat
 
     calls = {}
 
-    def fake_export(aois, config, ee_manager, sensor, logger=None):
-        calls["export"] = (aois, config, ee_manager, sensor)
+    def fake_export(aois, config, ee_manager, sensor, storage=None, logger=None):
+        calls["export"] = (aois, config, ee_manager, sensor, storage)
 
     monkeypatch.setattr(
         "verdesat.ingestion.earthengine_ingestor.export_chips", fake_export
@@ -122,3 +122,4 @@ def test_download_chips_delegation(dummy_aoi, dummy_sensor, monkeypatch, tmp_pat
     assert calls.get("export")
     assert calls["export"][0] == [dummy_aoi]
     assert calls["export"][1] is cfg
+    assert calls["export"][4] is None

--- a/tests/test_report_pipeline.py
+++ b/tests/test_report_pipeline.py
@@ -33,7 +33,9 @@ class DummyIngestor(BaseDataIngestor):
             {"id": [aoi.static_props["id"]], "date": [start_date], col: [0.5]}
         )
 
-    def download_chips(self, aois, config) -> None:  # pragma: no cover - simple stub
+    def download_chips(
+        self, aois, config, storage=None
+    ) -> None:  # pragma: no cover - simple stub
         self.chip_calls.append((len(aois), config.out_dir))
 
 

--- a/verdesat/analytics/ee_chipping.py
+++ b/verdesat/analytics/ee_chipping.py
@@ -9,6 +9,7 @@ from verdesat.ingestion.eemanager import EarthEngineManager
 from verdesat.ingestion.sensorspec import SensorSpec
 from verdesat.visualization._chips_config import ChipsConfig
 from verdesat.visualization.chips import ChipService
+from verdesat.core.storage import StorageAdapter
 from verdesat.core.logger import Logger
 
 
@@ -17,12 +18,14 @@ def export_chips(
     config: ChipsConfig,
     ee_manager: EarthEngineManager,
     sensor: SensorSpec,
+    storage: StorageAdapter | None = None,
     logger=None,
 ) -> None:
     """Export chips using ChipService."""
     service = ChipService(
         ee_manager=ee_manager,
         sensor_spec=sensor,
+        storage=storage,
         logger=logger or Logger.get_logger(__name__),
     )
     service.run(aois=aois, config=config)

--- a/verdesat/core/storage.py
+++ b/verdesat/core/storage.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+"""Storage adapter abstractions."""
+
+import os
+from abc import ABC, abstractmethod
+from typing import Any
+from urllib.parse import urlparse
+
+
+class StorageAdapter(ABC):
+    """Abstract interface for persisting binary data."""
+
+    @abstractmethod
+    def join(self, *parts: str) -> str:
+        """Join path components into a destination URI."""
+
+    @abstractmethod
+    def write_bytes(self, uri: str, data: bytes) -> str:
+        """Write bytes to the destination and return the URI."""
+
+
+class LocalFS(StorageAdapter):
+    """Store files on the local filesystem."""
+
+    def join(self, *parts: str) -> str:  # pragma: no cover - trivial
+        return os.path.join(*parts)
+
+    def write_bytes(self, uri: str, data: bytes) -> str:
+        os.makedirs(os.path.dirname(uri), exist_ok=True)
+        with open(uri, "wb") as fh:
+            fh.write(data)
+        return uri
+
+
+class S3Bucket(StorageAdapter):
+    """Store files in an S3 bucket using boto3."""
+
+    def __init__(self, bucket: str, client: Any | None = None) -> None:
+        try:
+            import boto3  # type: ignore
+        except ImportError as exc:  # pragma: no cover - optional
+            raise ImportError("boto3 is required for S3Bucket") from exc
+
+        self.bucket = bucket
+        self.client = client or boto3.client("s3")
+
+    def join(self, *parts: str) -> str:  # pragma: no cover - trivial
+        key = "/".join(p.strip("/") for p in parts)
+        return f"s3://{self.bucket}/{key}"
+
+    def write_bytes(self, uri: str, data: bytes) -> str:
+        parsed = urlparse(uri)
+        key = parsed.path.lstrip("/")
+        self.client.put_object(Bucket=parsed.netloc or self.bucket, Key=key, Body=data)
+        return uri

--- a/verdesat/ingestion/base.py
+++ b/verdesat/ingestion/base.py
@@ -11,6 +11,7 @@ from verdesat.core.logger import Logger
 from verdesat.geo.aoi import AOI
 from ..visualization._chips_config import ChipsConfig
 from .sensorspec import SensorSpec
+from verdesat.core.storage import StorageAdapter
 
 
 class BaseDataIngestor(ABC):
@@ -35,6 +36,11 @@ class BaseDataIngestor(ABC):
         """Download and optionally aggregate an index time series for an AOI."""
 
     @abstractmethod
-    def download_chips(self, aois: List[AOI], config: ChipsConfig) -> None:
+    def download_chips(
+        self,
+        aois: List[AOI],
+        config: ChipsConfig,
+        storage: StorageAdapter | None = None,
+    ) -> None:
         """Export image chips for the given AOIs using configuration."""
         raise NotImplementedError

--- a/verdesat/ingestion/earthengine_ingestor.py
+++ b/verdesat/ingestion/earthengine_ingestor.py
@@ -15,6 +15,7 @@ from .base import BaseDataIngestor
 from .downloader import EarthEngineDownloader
 from ..analytics.ee_masking import mask_collection
 from ..analytics.ee_chipping import export_chips
+from verdesat.core.storage import StorageAdapter
 from ..visualization._chips_config import ChipsConfig
 
 
@@ -78,7 +79,12 @@ class EarthEngineIngestor(BaseDataIngestor):
             return aggregated.df
         return raw_df
 
-    def download_chips(self, aois: List[AOI], config: ChipsConfig) -> None:
+    def download_chips(
+        self,
+        aois: List[AOI],
+        config: ChipsConfig,
+        storage: StorageAdapter | None = None,
+    ) -> None:
         """Export chips for the supplied AOIs using the given configuration."""
         self.ee.initialize()
         export_chips(
@@ -86,5 +92,6 @@ class EarthEngineIngestor(BaseDataIngestor):
             config=config,
             ee_manager=self.ee,
             sensor=self.sensor,
+            storage=storage,
             logger=self.logger,
         )


### PR DESCRIPTION
## Summary
- implement `StorageAdapter` with `LocalFS` and `S3Bucket`
- update `ChipExporter` to use `StorageAdapter`
- plumb storage through chip export services and ingestors
- adjust tests for new adapter design

## Testing
- `black verdesat tests`
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'shapely')*

------
https://chatgpt.com/codex/tasks/task_e_687953995b288321b28e5b3d0bfeda21