### PR TITLE
Add landcover service

### DIFF
--- a/tests/fixtures/stub_lc.tif
+++ b/tests/fixtures/stub_lc.tif
@@ -1,0 +1,1 @@
+DUMMYTIFF

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -59,3 +59,38 @@ def test_timeseries_value_col_passed(tmp_path, monkeypatch, dummy_aoi):
     )
     assert result.exit_code == 0
     assert calls["value_col"] == "mean_evi"
+
+
+def test_landcover_cli(monkeypatch, tmp_path, dummy_aoi):
+    calls = []
+
+    class DummySvc:
+        def __init__(self, logger=None):
+            pass
+
+        def download(self, aoi, year, out_dir):
+            calls.append((aoi, year, out_dir))
+
+    monkeypatch.setattr("verdesat.core.cli.LandcoverService", DummySvc)
+    monkeypatch.setattr(
+        "verdesat.core.cli.AOI.from_geojson", lambda p, id_col: [dummy_aoi]
+    )
+
+    runner = CliRunner()
+    geojson = tmp_path / "aoi.geojson"
+    geojson.write_text("{}")
+    out_dir = tmp_path / "out"
+    result = runner.invoke(
+        cli,
+        [
+            "download",
+            "landcover",
+            str(geojson),
+            "--year",
+            "2020",
+            "--out-dir",
+            str(out_dir),
+        ],
+    )
+    assert result.exit_code == 0
+    assert calls and calls[0][1] == 2020

--- a/tests/test_landcover_service.py
+++ b/tests/test_landcover_service.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from verdesat.services.landcover import LandcoverService
+from verdesat.core.logger import Logger
+
+
+def _dummy_image(url: str):
+    class Img:
+        def remap(self, *_a):
+            return self
+
+        def clip(self, _g):
+            return self
+
+        def getDownloadURL(self, _p):
+            return url
+
+    return Img()
+
+
+def _setup(monkeypatch, svc, calls, stub_bytes):
+    monkeypatch.setattr(
+        svc,
+        "_esri_image",
+        lambda year: (calls.setdefault("esri", year), _dummy_image("http://x"))[1],
+    )
+    monkeypatch.setattr(
+        svc,
+        "_worldcover_image",
+        lambda: (calls.setdefault("wc", True), _dummy_image("http://x"))[1],
+    )
+
+    class Resp:
+        def __init__(self, data: bytes):
+            self.content = data
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(
+        "verdesat.services.landcover.requests.get",
+        lambda url, timeout: Resp(stub_bytes),
+    )
+    monkeypatch.setattr("verdesat.services.landcover.ee.List", list)
+
+
+def test_download_selects_esri(monkeypatch, tmp_path, dummy_aoi):
+    calls: dict = {}
+    svc = LandcoverService(logger=Logger.get_logger("test"))
+    stub = Path("tests/fixtures/stub_lc.tif").read_bytes()
+    _setup(monkeypatch, svc, calls, stub)
+    monkeypatch.setattr(dummy_aoi, "buffered_ee_geometry", lambda x: MagicMock())
+
+    out = svc.download(dummy_aoi, 2018, str(tmp_path))
+    assert calls.get("esri") == 2018
+    assert Path(out).read_bytes() == stub
+
+
+def test_download_fallback_worldcover(monkeypatch, tmp_path, dummy_aoi):
+    calls: dict = {}
+    svc = LandcoverService(logger=Logger.get_logger("test"))
+    stub = Path("tests/fixtures/stub_lc.tif").read_bytes()
+    _setup(monkeypatch, svc, calls, stub)
+    monkeypatch.setattr(dummy_aoi, "buffered_ee_geometry", lambda x: MagicMock())
+
+    out = svc.download(dummy_aoi, 2015, str(tmp_path))
+    assert calls.get("wc") is True
+    assert Path(out).read_bytes() == stub

--- a/verdesat/services/__init__.py
+++ b/verdesat/services/__init__.py
@@ -2,5 +2,6 @@
 
 from .timeseries import download_timeseries
 from .report import build_report
+from .landcover import LandcoverService
 
-__all__ = ["download_timeseries", "build_report"]
+__all__ = ["download_timeseries", "build_report", "LandcoverService"]

--- a/verdesat/services/landcover.py
+++ b/verdesat/services/landcover.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+"""Service to fetch land-cover data from Earth Engine."""
+
+from datetime import datetime
+import logging
+from typing import Dict
+
+import ee
+import requests
+from ee import EEException
+
+from verdesat.core.logger import Logger
+from verdesat.core.storage import LocalFS, StorageAdapter
+from verdesat.geo.aoi import AOI
+from verdesat.ingestion.eemanager import ee_manager
+
+# Mapping of dataset-specific class codes to five-category scheme
+CLASS_MAP_5: Dict[int, int] = {
+    2: 1,  # ESRI Trees -> forest
+    6: 2,  # ESRI Shrub
+    5: 3,  # ESRI Crops
+    7: 4,  # ESRI Built area
+    8: 5,  # ESRI Bare ground
+    10: 1,  # ESA Tree cover
+    20: 2,  # ESA Shrubland
+    40: 3,  # ESA Cropland
+    50: 4,  # ESA Built-up
+    60: 5,  # ESA Bare
+}
+
+
+class BaseService:
+    """Minimal base class providing a logger."""
+
+    def __init__(self, logger: logging.Logger | None = None) -> None:  # noqa: D401
+        self.logger = logger or Logger.get_logger(self.__class__.__name__)
+
+
+class LandcoverService(BaseService):
+    """Retrieve annual 10 m land-cover rasters."""
+
+    ESRI_COLLECTION = "projects/sat-io/open-datasets/landcover/ESRI_Global-LULC_10m_TS"
+    WORLD_COVER_COLLECTION = "ESA/WorldCover/v200"
+
+    def __init__(
+        self,
+        storage: StorageAdapter | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        super().__init__(logger=logger)
+        self.ee = ee_manager
+        self.storage = storage or LocalFS()
+
+    @staticmethod
+    def _latest_year() -> int:
+        return datetime.utcnow().year
+
+    def _esri_image(self, year: int) -> ee.Image:
+        coll = ee.ImageCollection(self.ESRI_COLLECTION).filter(
+            ee.Filter.eq("year", year)
+        )
+        return coll.first()
+
+    def _worldcover_image(self) -> ee.Image:
+        coll = ee.ImageCollection(self.WORLD_COVER_COLLECTION).filter(
+            ee.Filter.eq("year", 2021)
+        )
+        return coll.first().select("Map")
+
+    def _get_raw_image(self, year: int) -> ee.Image:
+        if 2017 <= year <= self._latest_year():
+            return self._esri_image(year)
+        return self._worldcover_image()
+
+    def download(self, aoi: AOI, year: int, out_dir: str) -> str:
+        """Download land-cover raster for *aoi* and *year* into *out_dir*."""
+        self.ee.initialize()
+        geom = aoi.buffered_ee_geometry(0)
+        img = (
+            self._get_raw_image(year)
+            .remap(
+                ee.List(list(CLASS_MAP_5.keys())),
+                ee.List(list(CLASS_MAP_5.values())),
+            )
+            .clip(geom)
+        )
+        try:
+            url = img.getDownloadURL({"scale": 10, "region": geom})
+        except EEException as err:  # pragma: no cover - network error
+            self.logger.error("Failed to create download URL: %s", err)
+            raise
+
+        pid = aoi.static_props.get("id", "aoi")
+        filename = f"landcover_{pid}_{year}.tif"
+        dest = self.storage.join(out_dir, filename)
+        try:
+            resp = requests.get(url, timeout=60)
+            resp.raise_for_status()
+            self.storage.write_bytes(dest, resp.content)
+            self.logger.info("\u2714 Wrote landcover: %s", dest)
+        except requests.RequestException as err:  # pragma: no cover - network
+            self.logger.error("Download failed: %s", err)
+            raise
+        return dest


### PR DESCRIPTION
## Summary
- implement `LandcoverService` for retrieving annual land-cover rasters
- expose service in API and CLI
- provide CLI command `download landcover`
- create tests and stub raster

## Testing
- `black . && mypy`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688231d0fe7c8321a3eb923f15e4d55d