### PR TITLE
Add landcover service

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ in a configuration file loaded by `ConfigManager`.
   GeoJSON.
 - `download timeseries` – fetch spectral index values for each polygon.
 - `download chips` – export yearly or monthly imagery chips.
+- `download landcover` – export 10 m land-cover rasters.
+  Example: `verdesat download landcover aoi.geojson --year 2021 --out-dir landcover`.
+  Uses the ESRI dataset when available and falls back to ESA WorldCover.
+  Outputs are named `LANDCOVER_<id>_<year>.tiff`.
 - `preprocess fill-gaps` – interpolate missing values in a CSV.
 - `stats aggregate` – resample daily data to monthly or yearly.
 - `stats decompose` – seasonal decomposition with optional plots.

--- a/tests/test_chips_exporter.py
+++ b/tests/test_chips_exporter.py
@@ -93,10 +93,10 @@ def test_export_one_thumbnail_geotiff_cog(
 
     # Patch inside the module under test, not just globals()
     monkeypatch.setattr(
-        "verdesat.visualization.chips.rasterio", fake_rasterio, raising=False
+        "verdesat.services.raster_utils.rasterio", fake_rasterio, raising=False
     )
     monkeypatch.setattr(
-        "verdesat.visualization.chips.Resampling",
+        "verdesat.services.raster_utils.Resampling",
         SimpleNamespace(nearest="nearest"),
         raising=False,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,9 +79,10 @@ def test_landcover_cli(monkeypatch, tmp_path):
             str(geojson),
             "--year",
             "2021",
-            "--output",
-            "out.tif",
+            "--out-dir",
+            "dest",
         ],
     )
     assert result.exit_code == 0
     assert svc.download.called
+    assert svc.download.call_args.args[2] == "dest"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,3 +86,28 @@ def test_landcover_cli(monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert svc.download.called
     assert svc.download.call_args.args[2] == "dest"
+
+
+def test_landcover_cli_multiple_polygons(monkeypatch, tmp_path):
+    svc = MagicMock()
+    monkeypatch.setattr("verdesat.core.cli.LandcoverService", lambda logger=None: svc)
+
+    runner = CliRunner()
+    geojson = tmp_path / "aoi.geojson"
+    geojson.write_text(
+        '{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[0,1],[1,1],[1,0],[0,0]]]},"properties":{"id":1}},{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[1,1],[1,2],[2,2],[2,1],[1,1]]]},"properties":{"id":2}}]}'
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "download",
+            "landcover",
+            str(geojson),
+            "--year",
+            "2021",
+            "--out-dir",
+            "dest",
+        ],
+    )
+    assert result.exit_code == 0
+    assert svc.download.call_count == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from click.testing import CliRunner
+from unittest.mock import MagicMock
 
 from verdesat.core.cli import cli
 
@@ -59,3 +60,28 @@ def test_timeseries_value_col_passed(tmp_path, monkeypatch, dummy_aoi):
     )
     assert result.exit_code == 0
     assert calls["value_col"] == "mean_evi"
+
+
+def test_landcover_cli(monkeypatch, tmp_path):
+    svc = MagicMock()
+    monkeypatch.setattr("verdesat.core.cli.LandcoverService", lambda logger=None: svc)
+
+    runner = CliRunner()
+    geojson = tmp_path / "aoi.geojson"
+    geojson.write_text(
+        '{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[0,0],[0,1],[1,1],[1,0],[0,0]]]},"properties":{"id":1}}]}'
+    )
+    result = runner.invoke(
+        cli,
+        [
+            "download",
+            "landcover",
+            str(geojson),
+            "--year",
+            "2021",
+            "--output",
+            "out.tif",
+        ],
+    )
+    assert result.exit_code == 0
+    assert svc.download.called

--- a/tests/test_landcover_service.py
+++ b/tests/test_landcover_service.py
@@ -132,8 +132,10 @@ def test_download_writes_file(tmp_path, monkeypatch, dummy_aoi):
     fake_rasterio = MagicMock()
     ctx = fake_rasterio.open.return_value.__enter__.return_value
     ctx.read.return_value = b""
+    ctx.dataset_mask.return_value = b""
     ctx.profile = {}
     ctx.write = MagicMock()
+    ctx.write_mask = MagicMock()
     ctx.build_overviews = MagicMock()
     ctx.update_tags = MagicMock()
     monkeypatch.setattr(
@@ -199,8 +201,12 @@ def test_download_fallback_on_missing_asset(tmp_path, monkeypatch, dummy_aoi):
         SimpleNamespace(get=lambda *_a, **_k: FakeResp()),
         raising=False,
     )
+    fake_rasterio = MagicMock()
+    ctx = fake_rasterio.open.return_value.__enter__.return_value
+    ctx.write_mask = MagicMock()
+    ctx.dataset_mask.return_value = b""
     monkeypatch.setattr(
-        "verdesat.services.landcover.rasterio", MagicMock(), raising=False
+        "verdesat.services.landcover.rasterio", fake_rasterio, raising=False
     )
     monkeypatch.setattr(
         "verdesat.services.landcover.Resampling",

--- a/tests/test_landcover_service.py
+++ b/tests/test_landcover_service.py
@@ -10,7 +10,9 @@ def test_dataset_choice_esri(monkeypatch, dummy_aoi):
     called = {}
 
     class DummyImg:
-        def remap(self, *a, **k):
+        def remap(self, keys, vals):
+            called["keys"] = keys
+            called["vals"] = vals
             return self
 
         def rename(self, *a, **k):
@@ -38,7 +40,9 @@ def test_dataset_fallback(monkeypatch, dummy_aoi):
     called = {}
 
     class DummyImg:
-        def remap(self, *a, **k):
+        def remap(self, keys, vals):
+            called["keys"] = keys
+            called["vals"] = vals
             return self
 
         def rename(self, *a, **k):
@@ -58,6 +62,8 @@ def test_dataset_fallback(monkeypatch, dummy_aoi):
     svc.get_image(dummy_aoi, LandcoverService.LATEST_ESRI_YEAR + 2)
 
     assert called["id"] == LandcoverService.WORLD_COVER
+    assert called["keys"] == list(LandcoverService.WORLD_COVER_CLASS_MAP_6.keys())
+    assert called["vals"] == list(LandcoverService.WORLD_COVER_CLASS_MAP_6.values())
 
 
 def test_download_writes_file(tmp_path, monkeypatch, dummy_aoi):

--- a/tests/test_landcover_service.py
+++ b/tests/test_landcover_service.py
@@ -26,10 +26,12 @@ def test_dataset_choice_esri(monkeypatch, dummy_aoi):
     monkeypatch.setattr("verdesat.services.landcover.ee.Image", fake_image)
     monkeypatch.setattr("verdesat.geo.aoi.AOI.ee_geometry", lambda self: "geom")
 
-    svc = LandcoverService(ee_manager_instance=MagicMock())
+    mgr = MagicMock()
+    svc = LandcoverService(ee_manager_instance=mgr)
     svc.get_image(dummy_aoi, 2019)
 
     assert LandcoverService.ESRI_COLLECTION in called["id"]
+    assert mgr.initialize.called
 
 
 def test_download_writes_file(tmp_path, monkeypatch, dummy_aoi):
@@ -63,8 +65,10 @@ def test_download_writes_file(tmp_path, monkeypatch, dummy_aoi):
         raising=False,
     )
 
-    svc = LandcoverService(ee_manager_instance=MagicMock())
+    mgr = MagicMock()
+    svc = LandcoverService(ee_manager_instance=mgr)
     out = tmp_path / "lc.tif"
     svc.download(dummy_aoi, 2021, str(out))
 
     assert out.exists() and out.read_bytes() == b"DATA"
+    assert mgr.initialize.called

--- a/tests/test_landcover_service.py
+++ b/tests/test_landcover_service.py
@@ -34,6 +34,32 @@ def test_dataset_choice_esri(monkeypatch, dummy_aoi):
     assert mgr.initialize.called
 
 
+def test_dataset_fallback(monkeypatch, dummy_aoi):
+    called = {}
+
+    class DummyImg:
+        def remap(self, *a, **k):
+            return self
+
+        def rename(self, *a, **k):
+            return self
+
+        def clip(self, *a, **k):
+            return self
+
+    def fake_image(img_id):
+        called["id"] = img_id
+        return DummyImg()
+
+    monkeypatch.setattr("verdesat.services.landcover.ee.Image", fake_image)
+    monkeypatch.setattr("verdesat.geo.aoi.AOI.ee_geometry", lambda self: "geom")
+
+    svc = LandcoverService(ee_manager_instance=MagicMock())
+    svc.get_image(dummy_aoi, LandcoverService.LATEST_ESRI_YEAR + 2)
+
+    assert called["id"] == LandcoverService.WORLD_COVER
+
+
 def test_download_writes_file(tmp_path, monkeypatch, dummy_aoi):
     class DummyImg:
         def remap(self, *a, **k):

--- a/tests/test_landcover_service.py
+++ b/tests/test_landcover_service.py
@@ -163,10 +163,10 @@ def test_download_writes_file(tmp_path, monkeypatch, dummy_aoi):
         transform_geom=lambda *_a, **_k: {"geom": True}
     )
     monkeypatch.setattr(
-        "verdesat.services.landcover.rasterio", fake_rasterio, raising=False
+        "verdesat.services.raster_utils.rasterio", fake_rasterio, raising=False
     )
     monkeypatch.setattr(
-        "verdesat.services.landcover.Resampling",
+        "verdesat.services.raster_utils.Resampling",
         SimpleNamespace(nearest="nearest"),
         raising=False,
     )
@@ -264,10 +264,10 @@ def test_download_fallback_on_missing_asset(tmp_path, monkeypatch, dummy_aoi):
         transform_geom=lambda *_a, **_k: {"geom": True}
     )
     monkeypatch.setattr(
-        "verdesat.services.landcover.rasterio", fake_rasterio, raising=False
+        "verdesat.services.raster_utils.rasterio", fake_rasterio, raising=False
     )
     monkeypatch.setattr(
-        "verdesat.services.landcover.Resampling",
+        "verdesat.services.raster_utils.Resampling",
         SimpleNamespace(nearest="nearest"),
         raising=False,
     )

--- a/tests/test_landcover_service.py
+++ b/tests/test_landcover_service.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock
+from types import SimpleNamespace
+
+import pytest
+
+from verdesat.services.landcover import LandcoverService
+
+
+def test_dataset_choice_esri(monkeypatch, dummy_aoi):
+    called = {}
+
+    class DummyImg:
+        def remap(self, *a, **k):
+            return self
+
+        def rename(self, *a, **k):
+            return self
+
+        def clip(self, *a, **k):
+            return self
+
+    def fake_image(img_id):
+        called["id"] = img_id
+        return DummyImg()
+
+    monkeypatch.setattr("verdesat.services.landcover.ee.Image", fake_image)
+    monkeypatch.setattr("verdesat.geo.aoi.AOI.ee_geometry", lambda self: "geom")
+
+    svc = LandcoverService(ee_manager_instance=MagicMock())
+    svc.get_image(dummy_aoi, 2019)
+
+    assert LandcoverService.ESRI_COLLECTION in called["id"]
+
+
+def test_download_writes_file(tmp_path, monkeypatch, dummy_aoi):
+    class DummyImg:
+        def remap(self, *a, **k):
+            return self
+
+        def rename(self, *a, **k):
+            return self
+
+        def clip(self, *a, **k):
+            return self
+
+        def getDownloadURL(self, _p):
+            return "http://example.com/lc.tif"
+
+    monkeypatch.setattr(
+        "verdesat.services.landcover.ee.Image", lambda *_a, **_k: DummyImg()
+    )
+    monkeypatch.setattr("verdesat.geo.aoi.AOI.ee_geometry", lambda self: "geom")
+
+    class FakeResp:
+        content = b"DATA"
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(
+        "verdesat.services.landcover.requests",
+        SimpleNamespace(get=lambda *_a, **_k: FakeResp()),
+        raising=False,
+    )
+
+    svc = LandcoverService(ee_manager_instance=MagicMock())
+    out = tmp_path / "lc.tif"
+    svc.download(dummy_aoi, 2021, str(out))
+
+    assert out.exists() and out.read_bytes() == b"DATA"

--- a/tests/test_landcover_service.py
+++ b/tests/test_landcover_service.py
@@ -28,6 +28,10 @@ def test_dataset_choice_esri(monkeypatch, dummy_aoi):
             called["vals"] = vals
             return self
 
+        def unmask(self, val):
+            called["unmask"] = val
+            return self
+
         def rename(self, *_a, **_k):
             return self
 
@@ -47,6 +51,7 @@ def test_dataset_choice_esri(monkeypatch, dummy_aoi):
     assert called["cid"] == LandcoverService.ESRI_COLLECTION
     assert list(called["keys"]) == list(LandcoverService.ESRI_CLASS_MAP_6.keys())
     assert list(called["vals"]) == list(LandcoverService.ESRI_CLASS_MAP_6.values())
+    assert called["unmask"] == 0
     assert mgr.initialize.called
 
 
@@ -57,6 +62,10 @@ def test_dataset_fallback(monkeypatch, dummy_aoi):
         def remap(self, keys, vals):
             called["keys"] = keys
             called["vals"] = vals
+            return self
+
+        def unmask(self, val):
+            called["unmask"] = val
             return self
 
         def rename(self, *_a, **_k):
@@ -78,11 +87,15 @@ def test_dataset_fallback(monkeypatch, dummy_aoi):
     assert called["id"] == LandcoverService.WORLD_COVER
     assert called["keys"] == list(LandcoverService.WORLD_COVER_CLASS_MAP_6.keys())
     assert called["vals"] == list(LandcoverService.WORLD_COVER_CLASS_MAP_6.values())
+    assert called["unmask"] == 0
 
 
 def test_download_writes_file(tmp_path, monkeypatch, dummy_aoi):
     class DummyImg:
         def remap(self, *a, **k):
+            return self
+
+        def unmask(self, _val):
             return self
 
         def rename(self, *a, **k):
@@ -146,6 +159,9 @@ def test_download_fallback_on_missing_asset(tmp_path, monkeypatch, dummy_aoi):
 
     class ImgMissing:
         def remap(self, *a, **k):
+            return self
+
+        def unmask(self, _val):
             return self
 
         def rename(self, *a, **k):

--- a/tests/test_raster_utils.py
+++ b/tests/test_raster_utils.py
@@ -1,0 +1,50 @@
+import numpy as np
+from shapely.geometry import box
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from verdesat.services.raster_utils import convert_to_cog
+from verdesat.core.storage import LocalFS
+
+
+def test_convert_to_cog_multiband(monkeypatch, tmp_path):
+    # setup fake rasterio
+    fake_rasterio = SimpleNamespace()
+    ctx = MagicMock()
+    fake_rasterio.open = MagicMock(
+        return_value=MagicMock(
+            __enter__=MagicMock(return_value=ctx), __exit__=MagicMock()
+        )
+    )
+    ctx.profile = {"count": 3}
+    ctx.crs = SimpleNamespace(to_string=lambda: "EPSG:4326")
+    ctx.write = MagicMock()
+    ctx.write_mask = MagicMock()
+    ctx.build_overviews = MagicMock()
+    ctx.update_tags = MagicMock()
+
+    arr = np.ma.MaskedArray(
+        data=np.ones((3, 2, 2), dtype=np.uint8),
+        mask=np.zeros((3, 2, 2), dtype=bool),
+    )
+    fake_rasterio.mask = SimpleNamespace(mask=lambda *_a, **_k: (arr, "affine"))
+    fake_rasterio.warp = SimpleNamespace(transform_geom=lambda *_a, **_k: {})
+
+    monkeypatch.setattr(
+        "verdesat.services.raster_utils.rasterio", fake_rasterio, raising=False
+    )
+    monkeypatch.setattr(
+        "verdesat.services.raster_utils.Resampling",
+        SimpleNamespace(nearest="nearest"),
+        raising=False,
+    )
+
+    out = tmp_path / "test.tif"
+    out.write_bytes(b"data")
+
+    convert_to_cog(str(out), LocalFS(), geometry=box(0, 0, 1, 1))
+
+    # ensure all bands written
+    written = ctx.write.call_args[0][0]
+    assert written.shape[0] == 3
+    ctx.write_mask.assert_called()

--- a/verdesat/core/cli.py
+++ b/verdesat/core/cli.py
@@ -23,6 +23,7 @@ from verdesat.ingestion.eemanager import ee_manager
 from verdesat.services.timeseries import download_timeseries as svc_download_timeseries
 from verdesat.services.report import build_report as svc_build_report
 from verdesat.services.landcover import LandcoverService
+from verdesat.core.storage import LocalFS
 from verdesat.visualization._chips_config import ChipsConfig
 from verdesat.visualization.chips import ChipService
 from verdesat.visualization.visualizer import Visualizer
@@ -357,7 +358,7 @@ def landcover(geojson, year, out_dir):
         aois = AOI.from_geojson(geojson, id_col="id")
         if not aois:
             raise ValueError("No AOIs found")
-        svc = LandcoverService(logger=logger)
+        svc = LandcoverService(logger=logger, storage=LocalFS())
         for aoi in aois:
             svc.download(aoi, year, out_dir)
         echo(f"✅  Landcover rasters written under {out_dir}/")

--- a/verdesat/core/cli.py
+++ b/verdesat/core/cli.py
@@ -345,21 +345,21 @@ def chips(
 @click.argument("geojson", type=click.Path(exists=True))
 @click.option("--year", "-y", type=int, required=True, help="Year of landcover")
 @click.option(
-    "--output",
+    "--out-dir",
     "-o",
     type=click.Path(),
-    default="landcover.tif",
-    help="Output GeoTIFF path",
+    default="landcover",
+    help="Output directory",
 )
-def landcover(geojson, year, output):
+def landcover(geojson, year, out_dir):
     """Download 10 m land-cover raster for the first polygon in GEOJSON."""
     try:
         aois = AOI.from_geojson(geojson, id_col="id")
         if not aois:
             raise ValueError("No AOIs found")
         svc = LandcoverService(logger=logger)
-        svc.download(aois[0], year, output)
-        echo(f"✅  Landcover saved to {output}")
+        dest = svc.download(aois[0], year, out_dir)
+        echo(f"✅  Landcover saved to {dest}")
     # pylint: disable=broad-exception-caught
     except Exception as e:
         logger.error("Landcover command failed", exc_info=True)

--- a/verdesat/core/cli.py
+++ b/verdesat/core/cli.py
@@ -352,14 +352,15 @@ def chips(
     help="Output directory",
 )
 def landcover(geojson, year, out_dir):
-    """Download 10 m land-cover raster for the first polygon in GEOJSON."""
+    """Download 10 m land-cover rasters for all polygons in GEOJSON."""
     try:
         aois = AOI.from_geojson(geojson, id_col="id")
         if not aois:
             raise ValueError("No AOIs found")
         svc = LandcoverService(logger=logger)
-        dest = svc.download(aois[0], year, out_dir)
-        echo(f"✅  Landcover saved to {dest}")
+        for aoi in aois:
+            svc.download(aoi, year, out_dir)
+        echo(f"✅  Landcover rasters written under {out_dir}/")
     # pylint: disable=broad-exception-caught
     except Exception as e:
         logger.error("Landcover command failed", exc_info=True)

--- a/verdesat/services/__init__.py
+++ b/verdesat/services/__init__.py
@@ -1,7 +1,15 @@
 """Lightweight service-layer helpers used by the CLI and tests."""
 
-from .timeseries import download_timeseries
-from .report import build_report
-from .landcover import LandcoverService
+from importlib import import_module
 
 __all__ = ["download_timeseries", "build_report", "LandcoverService"]
+
+
+def __getattr__(name):
+    if name == "download_timeseries":
+        return import_module(".timeseries", __name__).download_timeseries
+    if name == "build_report":
+        return import_module(".report", __name__).build_report
+    if name == "LandcoverService":
+        return import_module(".landcover", __name__).LandcoverService
+    raise AttributeError(name)

--- a/verdesat/services/__init__.py
+++ b/verdesat/services/__init__.py
@@ -2,5 +2,6 @@
 
 from .timeseries import download_timeseries
 from .report import build_report
+from .landcover import LandcoverService
 
-__all__ = ["download_timeseries", "build_report"]
+__all__ = ["download_timeseries", "build_report", "LandcoverService"]

--- a/verdesat/services/base.py
+++ b/verdesat/services/base.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+"""Minimal service base class providing a logger."""
+
+import logging
+from verdesat.core.logger import Logger
+
+
+class BaseService:
+    """Base class for service helpers."""
+
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        self.logger = logger or Logger.get_logger(__name__)

--- a/verdesat/services/landcover.py
+++ b/verdesat/services/landcover.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Service for retrieving 10 m land-cover rasters."""
+
+from datetime import datetime
+from typing import Dict
+import logging
+
+import ee
+import requests
+
+from verdesat.geo.aoi import AOI
+from verdesat.ingestion.eemanager import EarthEngineManager, ee_manager
+from .base import BaseService
+
+
+class LandcoverService(BaseService):
+    """Retrieve annual land-cover rasters from Earth Engine."""
+
+    ESRI_COLLECTION = "projects/sat-io/open-datasets/landcover/ESRI_Global-LULC_10m_TS"
+    WORLD_COVER = "ESA/WorldCover/v200/2021"
+
+    # Mapping of raw dataset classes to 6 consolidated classes
+    CLASS_MAP_6: Dict[int, int] = {
+        1: 6,  # Water
+        2: 1,  # Trees -> Forest
+        3: 2,  # Grass -> Shrub
+        4: 1,  # Flooded vegetation -> Forest
+        5: 3,  # Crops
+        6: 2,  # Shrub/Scrub -> Shrub
+        7: 4,  # Built area -> Urban
+        8: 5,  # Bare ground -> Bare
+        9: 5,  # Snow/Ice -> Bare
+        10: 5,  # Clouds -> Bare
+    }
+
+    def __init__(
+        self,
+        ee_manager_instance: EarthEngineManager = ee_manager,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        super().__init__(logger)
+        self.ee_manager = ee_manager_instance
+
+    def _dataset_for_year(self, year: int) -> str:
+        latest_year = datetime.utcnow().year
+        if 2017 <= year <= latest_year:
+            return f"{self.ESRI_COLLECTION}/{year}"
+        return self.WORLD_COVER
+
+    def get_image(self, aoi: AOI, year: int) -> ee.Image:
+        """Return the remapped land-cover image clipped to *aoi*."""
+
+        image_id = self._dataset_for_year(year)
+        self.logger.info("Loading landcover image %s", image_id)
+        img = ee.Image(image_id)
+        remapped = img.remap(
+            list(self.CLASS_MAP_6.keys()),
+            list(self.CLASS_MAP_6.values()),
+        ).rename("landcover")
+        return remapped.clip(aoi.ee_geometry())
+
+    def download(self, aoi: AOI, year: int, output: str, scale: int = 10) -> str:
+        """Download the land-cover raster and return the output path."""
+
+        img = self.get_image(aoi, year)
+        geom = aoi.ee_geometry()
+        url = img.getDownloadURL({"scale": scale, "region": geom})
+        resp = requests.get(url, timeout=60)
+        resp.raise_for_status()
+        with open(output, "wb") as f:
+            f.write(resp.content)
+        self.logger.info("Wrote landcover raster to %s", output)
+        return output

--- a/verdesat/services/landcover.py
+++ b/verdesat/services/landcover.py
@@ -41,6 +41,7 @@ class LandcoverService(BaseService):
         8: 5,  # Bare ground -> Bare
         9: 5,  # Snow/Ice -> Bare
         10: 5,  # Clouds -> Bare
+        11: 2,  # Rangeland -> Shrub
     }
 
     # Mapping of ESA WorldCover classes to 6 consolidated classes
@@ -94,10 +95,11 @@ class LandcoverService(BaseService):
             img = ee.Image(dataset)
             class_map = self.WORLD_COVER_CLASS_MAP_6
 
-        remapped = img.remap(
-            list(class_map.keys()),
-            list(class_map.values()),
-        ).rename("landcover")
+        remapped = (
+            img.remap(list(class_map.keys()), list(class_map.values()))
+            .unmask(0)
+            .rename("landcover")
+        )
         return remapped.clip(aoi.ee_geometry())
 
     def _convert_to_cog(self, path: str) -> None:

--- a/verdesat/services/landcover.py
+++ b/verdesat/services/landcover.py
@@ -114,7 +114,8 @@ class LandcoverService(BaseService):
         try:
             with rasterio.open(path) as src:
                 profile = src.profile
-                data = src.read()
+                data = src.read(1)
+                mask = src.dataset_mask()
 
             profile.update(
                 driver="GTiff",
@@ -125,7 +126,8 @@ class LandcoverService(BaseService):
             )
 
             with rasterio.open(path, "w", **profile) as dst:
-                dst.write(data)
+                dst.write(data, 1)
+                dst.write_mask(mask)
                 dst.build_overviews([2, 4, 8, 16], Resampling.nearest)
                 dst.update_tags(OVR_RESAMPLING="NEAREST")
 

--- a/verdesat/services/landcover.py
+++ b/verdesat/services/landcover.py
@@ -53,6 +53,7 @@ class LandcoverService(BaseService):
 
         image_id = self._dataset_for_year(year)
         self.logger.info("Loading landcover image %s", image_id)
+        self.ee_manager.initialize()
         img = ee.Image(image_id)
         remapped = img.remap(
             list(self.CLASS_MAP_6.keys()),

--- a/verdesat/services/landcover.py
+++ b/verdesat/services/landcover.py
@@ -143,16 +143,7 @@ class LandcoverService(BaseService):
         img = self.get_image(aoi, year)
         geom = aoi.ee_geometry()
 
-        region: ee.Geometry | list[float] = geom
-        try:
-            bbox_info = self.ee_manager.safe_get_info(geom.bounds()) or {}
-            coords = bbox_info.get("coordinates", [[]])[0]
-            if coords:
-                xs = [pt[0] for pt in coords]
-                ys = [pt[1] for pt in coords]
-                region = [min(xs), min(ys), max(xs), max(ys)]
-        except ee_exception.EEException as ee_err:  # pragma: no cover - safety
-            self.logger.warning("Could not compute bbox for AOI: %s", ee_err)
+        region: ee.Geometry = geom
 
         try:
             url = img.getDownloadURL(

--- a/verdesat/services/landcover.py
+++ b/verdesat/services/landcover.py
@@ -19,6 +19,7 @@ class LandcoverService(BaseService):
 
     ESRI_COLLECTION = "projects/sat-io/open-datasets/landcover/ESRI_Global-LULC_10m_TS"
     WORLD_COVER = "ESA/WorldCover/v200/2021"
+    LATEST_ESRI_YEAR = 2023
 
     # Mapping of raw dataset classes to 6 consolidated classes
     CLASS_MAP_6: Dict[int, int] = {
@@ -43,9 +44,14 @@ class LandcoverService(BaseService):
         self.ee_manager = ee_manager_instance
 
     def _dataset_for_year(self, year: int) -> str:
-        latest_year = datetime.utcnow().year
-        if 2017 <= year <= latest_year:
+        """Return dataset identifier appropriate for *year*."""
+
+        if 2017 <= year <= self.LATEST_ESRI_YEAR:
             return f"{self.ESRI_COLLECTION}/{year}"
+        if year > self.LATEST_ESRI_YEAR:
+            self.logger.warning(
+                "ESRI landcover for %s unavailable; falling back to WorldCover", year
+            )
         return self.WORLD_COVER
 
     def get_image(self, aoi: AOI, year: int) -> ee.Image:

--- a/verdesat/services/raster_utils.py
+++ b/verdesat/services/raster_utils.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+"""Utility helpers for raster operations."""
+
+from typing import Optional
+import logging
+from shapely.geometry.base import BaseGeometry
+from shapely.geometry import mapping
+
+try:
+    import rasterio
+    from rasterio.enums import Resampling
+    import rasterio.mask
+    import rasterio.warp
+except ImportError:  # pragma: no cover - optional
+    rasterio = None
+    Resampling = None
+
+from verdesat.core.storage import StorageAdapter, LocalFS
+
+
+def convert_to_cog(
+    path: str,
+    storage: StorageAdapter,
+    geometry: Optional[BaseGeometry] = None,
+    logger: Optional[logging.Logger] = None,
+) -> None:
+    """Convert *path* GeoTIFF to Cloud Optimized GeoTIFF.
+
+    If ``geometry`` is provided, clip the raster to that polygon. Conversion is
+    skipped when rasterio is missing or when ``storage`` is not ``LocalFS``.
+    """
+    logger = logger or logging.getLogger(__name__)
+    if not isinstance(storage, LocalFS):
+        logger.warning("COG conversion skipped for non-local storage: %s", path)
+        return
+
+    if rasterio is None or Resampling is None:
+        logger.warning("rasterio not installed; skipping COG conversion for %s", path)
+        return
+
+    try:
+        with rasterio.open(path) as src:
+            profile = src.profile
+            if geometry is not None:
+                geom_json = mapping(geometry)
+                if src.crs and src.crs.to_string() != "EPSG:4326":
+                    geom_json = rasterio.warp.transform_geom(
+                        "EPSG:4326", src.crs.to_string(), geom_json
+                    )
+                arr, transform = rasterio.mask.mask(
+                    src, [geom_json], crop=True, filled=False
+                )
+                profile.update(
+                    nodata=0,
+                    height=arr.shape[1],
+                    width=arr.shape[2],
+                    transform=transform,
+                )
+            else:
+                arr = src.read()
+
+        profile.update(
+            driver="GTiff",
+            compress="deflate",
+            tiled=True,
+            blockxsize=512,
+            blockysize=512,
+            count=arr.shape[0],
+        )
+
+        with rasterio.open(path, "w", **profile) as dst:
+            data = arr.filled(0)
+            dst.write(data)
+            if geometry is not None:
+                import numpy as np
+
+                mask = (~np.all(arr.mask, axis=0)).astype("uint8") * 255
+                dst.write_mask(mask)
+            dst.build_overviews([2, 4, 8, 16], Resampling.nearest)
+            dst.update_tags(OVR_RESAMPLING="NEAREST")
+        logger.info("\u2714 Converted to COG: %s", path)
+    except Exception as cog_err:  # pragma: no cover - optional broad catch
+        logger.warning("\u26a0 COG conversion failed for %s: %s", path, cog_err)


### PR DESCRIPTION
## Summary
- add base class for services
- implement `LandcoverService` with ESRI/ESA datasets
- expose new service in package init
- register `landcover` CLI command
- add unit tests for service and CLI

## Testing
- `black .`
- `mypy verdesat`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68829c0ee04c832185be6d1ba1b966af