### PR TITLE
Add storage adapter to LandcoverService

### DIFF
--- a/verdesat/core/cli.py
+++ b/verdesat/core/cli.py
@@ -23,6 +23,7 @@ from verdesat.ingestion.eemanager import ee_manager
 from verdesat.services.timeseries import download_timeseries as svc_download_timeseries
 from verdesat.services.report import build_report as svc_build_report
 from verdesat.services.landcover import LandcoverService
+from verdesat.core.storage import LocalFS
 from verdesat.visualization._chips_config import ChipsConfig
 from verdesat.visualization.chips import ChipService
 from verdesat.visualization.visualizer import Visualizer
@@ -357,7 +358,7 @@ def landcover(geojson, year, out_dir):
         aois = AOI.from_geojson(geojson, id_col="id")
         if not aois:
             raise ValueError("No AOIs found")
-        svc = LandcoverService(logger=logger)
+        svc = LandcoverService(logger=logger, storage=LocalFS())
         for aoi in aois:
             svc.download(aoi, year, out_dir)
         echo(f"✅  Landcover rasters written under {out_dir}/")


### PR DESCRIPTION
## Summary
- inject StorageAdapter into `LandcoverService`
- skip COG conversion when storage isn't local
- wire CLI to pass a LocalFS instance
- update landcover unit tests and CLI tests

## Testing
- `black . --quiet`
- `mypy verdesat`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883af3ec5e883219775d3c01d5eae4c