### PR TITLE
Refactor raster COG utils

### DIFF
--- a/tests/test_chips_exporter.py
+++ b/tests/test_chips_exporter.py
@@ -93,10 +93,10 @@ def test_export_one_thumbnail_geotiff_cog(
 
     # Patch inside the module under test, not just globals()
     monkeypatch.setattr(
-        "verdesat.visualization.chips.rasterio", fake_rasterio, raising=False
+        "verdesat.services.raster_utils.rasterio", fake_rasterio, raising=False
     )
     monkeypatch.setattr(
-        "verdesat.visualization.chips.Resampling",
+        "verdesat.services.raster_utils.Resampling",
         SimpleNamespace(nearest="nearest"),
         raising=False,
     )

--- a/tests/test_landcover_service.py
+++ b/tests/test_landcover_service.py
@@ -163,10 +163,10 @@ def test_download_writes_file(tmp_path, monkeypatch, dummy_aoi):
         transform_geom=lambda *_a, **_k: {"geom": True}
     )
     monkeypatch.setattr(
-        "verdesat.services.landcover.rasterio", fake_rasterio, raising=False
+        "verdesat.services.raster_utils.rasterio", fake_rasterio, raising=False
     )
     monkeypatch.setattr(
-        "verdesat.services.landcover.Resampling",
+        "verdesat.services.raster_utils.Resampling",
         SimpleNamespace(nearest="nearest"),
         raising=False,
     )
@@ -264,10 +264,10 @@ def test_download_fallback_on_missing_asset(tmp_path, monkeypatch, dummy_aoi):
         transform_geom=lambda *_a, **_k: {"geom": True}
     )
     monkeypatch.setattr(
-        "verdesat.services.landcover.rasterio", fake_rasterio, raising=False
+        "verdesat.services.raster_utils.rasterio", fake_rasterio, raising=False
     )
     monkeypatch.setattr(
-        "verdesat.services.landcover.Resampling",
+        "verdesat.services.raster_utils.Resampling",
         SimpleNamespace(nearest="nearest"),
         raising=False,
     )

--- a/tests/test_raster_utils.py
+++ b/tests/test_raster_utils.py
@@ -1,0 +1,50 @@
+import numpy as np
+from shapely.geometry import box
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from verdesat.services.raster_utils import convert_to_cog
+from verdesat.core.storage import LocalFS
+
+
+def test_convert_to_cog_multiband(monkeypatch, tmp_path):
+    # setup fake rasterio
+    fake_rasterio = SimpleNamespace()
+    ctx = MagicMock()
+    fake_rasterio.open = MagicMock(
+        return_value=MagicMock(
+            __enter__=MagicMock(return_value=ctx), __exit__=MagicMock()
+        )
+    )
+    ctx.profile = {"count": 3}
+    ctx.crs = SimpleNamespace(to_string=lambda: "EPSG:4326")
+    ctx.write = MagicMock()
+    ctx.write_mask = MagicMock()
+    ctx.build_overviews = MagicMock()
+    ctx.update_tags = MagicMock()
+
+    arr = np.ma.MaskedArray(
+        data=np.ones((3, 2, 2), dtype=np.uint8),
+        mask=np.zeros((3, 2, 2), dtype=bool),
+    )
+    fake_rasterio.mask = SimpleNamespace(mask=lambda *_a, **_k: (arr, "affine"))
+    fake_rasterio.warp = SimpleNamespace(transform_geom=lambda *_a, **_k: {})
+
+    monkeypatch.setattr(
+        "verdesat.services.raster_utils.rasterio", fake_rasterio, raising=False
+    )
+    monkeypatch.setattr(
+        "verdesat.services.raster_utils.Resampling",
+        SimpleNamespace(nearest="nearest"),
+        raising=False,
+    )
+
+    out = tmp_path / "test.tif"
+    out.write_bytes(b"data")
+
+    convert_to_cog(str(out), LocalFS(), geometry=box(0, 0, 1, 1))
+
+    # ensure all bands written
+    written = ctx.write.call_args[0][0]
+    assert written.shape[0] == 3
+    ctx.write_mask.assert_called()

--- a/verdesat/services/__init__.py
+++ b/verdesat/services/__init__.py
@@ -1,7 +1,15 @@
 """Lightweight service-layer helpers used by the CLI and tests."""
 
-from .timeseries import download_timeseries
-from .report import build_report
-from .landcover import LandcoverService
+from importlib import import_module
 
 __all__ = ["download_timeseries", "build_report", "LandcoverService"]
+
+
+def __getattr__(name):
+    if name == "download_timeseries":
+        return import_module(".timeseries", __name__).download_timeseries
+    if name == "build_report":
+        return import_module(".report", __name__).build_report
+    if name == "LandcoverService":
+        return import_module(".landcover", __name__).LandcoverService
+    raise AttributeError(name)

--- a/verdesat/services/raster_utils.py
+++ b/verdesat/services/raster_utils.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+"""Utility helpers for raster operations."""
+
+from typing import Optional
+import logging
+from shapely.geometry.base import BaseGeometry
+from shapely.geometry import mapping
+
+try:
+    import rasterio
+    from rasterio.enums import Resampling
+    import rasterio.mask
+    import rasterio.warp
+except ImportError:  # pragma: no cover - optional
+    rasterio = None
+    Resampling = None
+
+from verdesat.core.storage import StorageAdapter, LocalFS
+
+
+def convert_to_cog(
+    path: str,
+    storage: StorageAdapter,
+    geometry: Optional[BaseGeometry] = None,
+    logger: Optional[logging.Logger] = None,
+) -> None:
+    """Convert *path* GeoTIFF to Cloud Optimized GeoTIFF.
+
+    If ``geometry`` is provided, clip the raster to that polygon. Conversion is
+    skipped when rasterio is missing or when ``storage`` is not ``LocalFS``.
+    """
+    logger = logger or logging.getLogger(__name__)
+    if not isinstance(storage, LocalFS):
+        logger.warning("COG conversion skipped for non-local storage: %s", path)
+        return
+
+    if rasterio is None or Resampling is None:
+        logger.warning("rasterio not installed; skipping COG conversion for %s", path)
+        return
+
+    try:
+        with rasterio.open(path) as src:
+            profile = src.profile
+            if geometry is not None:
+                geom_json = mapping(geometry)
+                if src.crs and src.crs.to_string() != "EPSG:4326":
+                    geom_json = rasterio.warp.transform_geom(
+                        "EPSG:4326", src.crs.to_string(), geom_json
+                    )
+                arr, transform = rasterio.mask.mask(
+                    src, [geom_json], crop=True, filled=False
+                )
+                profile.update(
+                    nodata=0,
+                    height=arr.shape[1],
+                    width=arr.shape[2],
+                    transform=transform,
+                )
+            else:
+                arr = src.read()
+
+        profile.update(
+            driver="GTiff",
+            compress="deflate",
+            tiled=True,
+            blockxsize=512,
+            blockysize=512,
+        )
+
+        with rasterio.open(path, "w", **profile) as dst:
+            if geometry is not None:
+                dst.write(arr.data[0], 1)
+                mask = (~arr.mask[0]).astype("uint8") * 255
+                dst.write_mask(mask)
+            else:
+                dst.write(arr)
+            dst.build_overviews([2, 4, 8, 16], Resampling.nearest)
+            dst.update_tags(OVR_RESAMPLING="NEAREST")
+        logger.info("\u2714 Converted to COG: %s", path)
+    except Exception as cog_err:  # pragma: no cover - optional broad catch
+        logger.warning("\u26a0 COG conversion failed for %s: %s", path, cog_err)

--- a/verdesat/services/raster_utils.py
+++ b/verdesat/services/raster_utils.py
@@ -66,15 +66,17 @@ def convert_to_cog(
             tiled=True,
             blockxsize=512,
             blockysize=512,
+            count=arr.shape[0],
         )
 
         with rasterio.open(path, "w", **profile) as dst:
+            data = arr.filled(0)
+            dst.write(data)
             if geometry is not None:
-                dst.write(arr.data[0], 1)
-                mask = (~arr.mask[0]).astype("uint8") * 255
+                import numpy as np
+
+                mask = (~np.all(arr.mask, axis=0)).astype("uint8") * 255
                 dst.write_mask(mask)
-            else:
-                dst.write(arr)
             dst.build_overviews([2, 4, 8, 16], Resampling.nearest)
             dst.update_tags(OVR_RESAMPLING="NEAREST")
         logger.info("\u2714 Converted to COG: %s", path)


### PR DESCRIPTION
## Summary
- add raster-utils module for COG conversion
- refactor landcover and chip exporters to use new util
- lazy-load heavy service imports
- update unit tests

## Testing
- `black . --quiet`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b9db35f48321a0336af53bb43586