### PR TITLE
Add live compute mode with R2 upload

### DIFF
--- a/verdesat/webapp/services/r2.py
+++ b/verdesat/webapp/services/r2.py
@@ -65,3 +65,10 @@ def signed_url(key: str, expires: int = 86_400) -> str:
         Params={"Bucket": bucket, "Key": key},
         ExpiresIn=expires,
     )
+
+
+def upload_bytes(key: str, data: bytes, *, content_type: str = "text/csv") -> None:
+    """Upload ``data`` to R2 under ``key``."""
+
+    bucket = os.getenv("R2_BUCKET", "verdesat-data")
+    _client().put_object(Bucket=bucket, Key=key, Body=data, ContentType=content_type)


### PR DESCRIPTION
## Summary
- implement upload_bytes helper for R2
- support computing metrics for uploaded AOIs
- wire compute service into Streamlit dashboard

## Testing
- `pytest -q`
- `black . && mypy`


------
https://chatgpt.com/codex/tasks/task_e_688b5d52d5308321b86a8d6252377110