### PR TITLE
fix: compute real metrics for web app

### DIFF
--- a/verdesat/webapp/app.py
+++ b/verdesat/webapp/app.py
@@ -8,7 +8,7 @@ from verdesat.webapp.components.charts import (
     msavi_bar_chart,
     ndvi_decomposition_chart,
 )
-from verdesat.webapp.services.compute import load_demo_metrics, compute_live_metrics
+from verdesat.webapp.services.compute import compute_live_metrics, load_demo_metrics
 from verdesat.webapp.services.exports import export_metrics_csv, export_metrics_pdf
 
 # ---- Page config -----------------------------------------------------------
@@ -73,8 +73,9 @@ if run_button:
         current_gdf = gdf
         current_aoi_id = 0
     else:
-        metrics_data = load_demo_metrics(aoi_id)
-        current_gdf = DEMO_AOI
+        demo_gdf = DEMO_AOI[DEMO_AOI["id"] == aoi_id]
+        metrics_data = load_demo_metrics(aoi_id, demo_gdf, year=year)
+        current_gdf = demo_gdf
         current_aoi_id = aoi_id
     metrics = Metrics(**metrics_data)
     with col2:

--- a/verdesat/webapp/services/compute.py
+++ b/verdesat/webapp/services/compute.py
@@ -1,22 +1,30 @@
 from __future__ import annotations
 
-"""Lightweight helpers for computing demo metrics."""
+"""Utility functions for computing biodiversity metrics for the web app.
 
+The original implementation was a thin mock that returned hard-coded or
+placeholder values (e.g. ``msa`` was set to the MSAVI mean).  This module now
+leverages the real service layer used by the CLI, providing consistent
+calculations for the Streamlit dashboard.  It exposes helpers for both the
+demo AOIs and user provided uploads.
+"""
+
+from pathlib import Path
+import tempfile
+
+import geopandas as gpd
 import numpy as np
+import pandas as pd
 import rasterio
 
-import tempfile
-import geopandas as gpd
-import pandas as pd
-
-from verdesat.webapp.services.r2 import signed_url, upload_bytes
+from verdesat.analytics.stats import compute_summary_stats
 from verdesat.services.bscore import compute_bscores
+from verdesat.services.msa import MSAService
+from verdesat.services.timeseries import download_timeseries
+from verdesat.webapp.services.r2 import signed_url, upload_bytes
 
 from verdesat.biodiv.bscore import BScoreCalculator, WeightsConfig
-from verdesat.biodiv.metrics import MetricsResult, FragmentStats
-
-
-THRESHOLD = 0.5
+from verdesat.biodiv.metrics import FragmentStats, MetricsResult
 
 
 def _read_remote_raster(key: str) -> np.ndarray:
@@ -32,12 +40,26 @@ def _basic_stats(arr: np.ndarray) -> tuple[float, float]:
     return float(np.nanmean(arr[mask])), float(np.nanstd(arr[mask]))
 
 
-def load_demo_metrics(aoi_id: int) -> dict[str, float]:
-    """Compute metrics for a demo AOI using rasters stored on R2."""
+def load_demo_metrics(
+    aoi_id: int, gdf: gpd.GeoDataFrame, *, year: int
+) -> dict[str, float]:
+    """Compute metrics for a demo AOI using rasters stored on R2.
 
-    ndvi = _read_remote_raster(f"resources/NDVI_{aoi_id}_2024-01-01.tif")
-    msavi = _read_remote_raster(f"resources/MSAVI_{aoi_id}_2024-01-01.tif")
-    landcover = _read_remote_raster(f"resources/LANDCOVER_{aoi_id}_2024.tiff")
+    Parameters
+    ----------
+    aoi_id:
+        Identifier of the AOI within ``gdf``.
+    gdf:
+        GeoDataFrame containing all demo AOIs. The geometry is required to
+        compute MSA using :class:`~verdesat.services.msa.MSAService`.
+    year:
+        Year used for land-cover based metrics. Currently only 2024 demo rasters
+        are available.
+    """
+
+    ndvi = _read_remote_raster(f"resources/NDVI_{aoi_id}_{year}-01-01.tif")
+    msavi = _read_remote_raster(f"resources/MSAVI_{aoi_id}_{year}-01-01.tif")
+    landcover = _read_remote_raster(f"resources/LANDCOVER_{aoi_id}_{year}.tiff")
 
     intactness = float(np.isin(landcover, [1, 2, 6]).sum() / landcover.size)
 
@@ -54,6 +76,13 @@ def load_demo_metrics(aoi_id: int) -> dict[str, float]:
     ndvi_mean, ndvi_std = _basic_stats(ndvi)
     msavi_mean, msavi_std = _basic_stats(msavi)
 
+    msa_val = float("nan")
+    try:
+        geom = gdf.loc[gdf["id"] == aoi_id].geometry.iloc[0]
+        msa_val = MSAService().mean_msa(geom)
+    except Exception:  # pragma: no cover - network or raster issues
+        pass
+
     calc = BScoreCalculator(WeightsConfig())
     metrics = MetricsResult(
         intactness=intactness,
@@ -62,7 +91,7 @@ def load_demo_metrics(aoi_id: int) -> dict[str, float]:
             edge_density=fragmentation,
             normalised_density=fragmentation,
         ),
-        msa=msavi_mean,
+        msa=msa_val,
     )
     bscore = calc.score(metrics)
 
@@ -78,23 +107,58 @@ def load_demo_metrics(aoi_id: int) -> dict[str, float]:
     }
 
 
+def _vi_stats(aoi_path: str, index: str, year: int) -> tuple[float, float]:
+    """Return mean and standard deviation for a spectral index.
+
+    The function downloads a time series for ``index`` using the existing
+    :func:`~verdesat.services.timeseries.download_timeseries` helper and then
+    summarises it via :func:`~verdesat.analytics.stats.compute_summary_stats`.
+    Any error while fetching the time series results in ``nan`` values to avoid
+    breaking the web application when optional dependencies are missing.
+    """
+
+    try:
+        ts_df = download_timeseries(
+            geojson=aoi_path,
+            start=f"{year}-01-01",
+            end=f"{year}-12-31",
+            index=index,
+            chunk_freq="ME",
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = Path(tmpdir) / f"{index}.csv"
+            ts_df.to_csv(csv_path, index=False)
+            stats_df = compute_summary_stats(
+                str(csv_path), value_col=f"mean_{index}"
+            ).to_dataframe()
+        row = stats_df.iloc[0]
+        mean_key = f"Mean {index.upper()}"
+        std_key = f"Std {index.upper()}"
+        return float(row[mean_key]), float(row[std_key])
+    except Exception:  # pragma: no cover - network or EE failures
+        return float("nan"), float("nan")
+
+
 def compute_live_metrics(gdf: gpd.GeoDataFrame, *, year: int) -> dict[str, float]:
     """Compute metrics for an uploaded AOI and persist the CSV to R2."""
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        aoi_path = f"{tmpdir}/aoi.geojson"
+        aoi_path = Path(tmpdir) / "aoi.geojson"
         gdf.to_file(aoi_path, driver="GeoJSON")
-        df: pd.DataFrame = compute_bscores(aoi_path, year=year)
+        df: pd.DataFrame = compute_bscores(str(aoi_path), year=year)
+        ndvi_mean, ndvi_std = _vi_stats(str(aoi_path), "ndvi", year)
+        msavi_mean, msavi_std = _vi_stats(str(aoi_path), "msavi", year)
         csv_bytes = df.to_csv(index=False).encode("utf-8")
         upload_bytes("results/live_metrics.csv", csv_bytes, content_type="text/csv")
+
     row = df.iloc[0]
     return {
         "intactness": float(row["intactness"]),
         "shannon": float(row["shannon"]),
         "fragmentation": float(row["fragmentation"]),
-        "ndvi_mean": float("nan"),
-        "ndvi_std": float("nan"),
-        "msavi_mean": row.get("msa", float("nan")),
-        "msavi_std": float("nan"),
+        "ndvi_mean": ndvi_mean,
+        "ndvi_std": ndvi_std,
+        "msavi_mean": msavi_mean,
+        "msavi_std": msavi_std,
         "bscore": float(row["bscore"]),
     }


### PR DESCRIPTION
## Summary
- compute MSA separately from MSAVI and hook up real service layer for demo metrics
- derive NDVI/MSAVI stats for live computations using timeseries and summary helpers
- wire Streamlit demo to use updated metrics functions

## Testing
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c9bdaa2948321bfaf2049d085bcae