### PR TITLE
feat: optimize compute service performance

### DIFF
--- a/verdesat/analytics/stats.py
+++ b/verdesat/analytics/stats.py
@@ -1,28 +1,42 @@
 # verdesat/analytics/stats.py
 
+import io
+from pathlib import Path
+from typing import IO, Mapping, Optional
+
+import numpy as np
 import pandas as pd
 from pandas import Timestamp
-import numpy as np
-from pathlib import Path
-from typing import List, Dict, Optional
-from scipy.stats import theilslopes, kendalltau
+from scipy.stats import kendalltau, theilslopes
+
 from verdesat.core.config import ConfigManager
 from .results import StatsResult
 
 
 def compute_summary_stats(
-    timeseries_csv: str,
-    trend_csv: Optional[str] = None,
-    decomp_dir: Optional[str] = None,
+    timeseries_csv: str | IO[bytes] | pd.DataFrame,
+    trend_csv: Optional[str | IO[bytes] | pd.DataFrame] = None,
+    decomp_dir: Optional[str | Mapping[int, IO[bytes] | pd.DataFrame]] = None,
     period: Optional[int] = 1,
     value_col: str = ConfigManager.VALUE_COL_TEMPLATE.format(
         index=ConfigManager.DEFAULT_INDEX
     ),
 ) -> StatsResult:
-    """Build per-site summary stats and return them as a :class:`StatsResult`."""
+    """Build per-site summary stats and return them as a :class:`StatsResult`.
+
+    ``timeseries_csv`` may be a path, file-like object or DataFrame. ``decomp_dir``
+    accepts either a directory path or a mapping of site IDs to in-memory CSV
+    buffers/DataFrames containing decomposition results.
+    """
     # 1) Load and pivot
-    df = pd.read_csv(timeseries_csv, parse_dates=["date"])
-    stats = []
+    if isinstance(timeseries_csv, pd.DataFrame):
+        df = timeseries_csv.copy()
+        if not pd.api.types.is_datetime64_any_dtype(df["date"]):
+            df["date"] = pd.to_datetime(df["date"])
+    else:
+        df = pd.read_csv(timeseries_csv, parse_dates=["date"])
+
+    stats: list[dict[str, float | int | str | None]] = []
     for pid, grp in df.groupby("id"):
         grp = grp.sort_values("date").set_index("date")
         n = len(grp)
@@ -42,40 +56,43 @@ def compute_summary_stats(
 
         seasonal_amp = np.nan
         resid_rms = np.nan
-        peak_month = None
+        peak_month: str | None = None
+        ddf = None
         if decomp_dir:
-            decomp_path = Path(decomp_dir) / f"{pid}_decomposition.csv"
-            if decomp_path.exists():
-                ddf = pd.read_csv(decomp_path, parse_dates=["date"]).set_index("date")
-                if period is not None and len(ddf) >= 2 * period:
-                    seasonal = ddf["seasonal"]
-                    resid = ddf["resid"]
-                    seasonal_amp = seasonal.max() - seasonal.min()
-                    resid_rms = np.sqrt((resid**2).mean())
-                    # peak seasonal month
-                    peak_month = None
-                    if not seasonal.empty:
-                        idx = seasonal.idxmax()
-                        # idx should be a pandas Timestamp; guard before formatting
-                        if isinstance(idx, Timestamp):
-                            peak_month = idx.strftime("%Y-%m")
-                        else:
-                            peak_month = str(idx)
+            if isinstance(decomp_dir, Mapping):
+                buf = decomp_dir.get(pid)
+                if isinstance(buf, pd.DataFrame):
+                    ddf = buf.set_index("date")
+                elif buf is not None:
+                    if isinstance(buf, io.BytesIO):
+                        buf.seek(0)
+                    ddf = pd.read_csv(buf, parse_dates=["date"]).set_index("date")
+            else:
+                decomp_path = Path(decomp_dir) / f"{pid}_decomposition.csv"
+                if decomp_path.exists():
+                    ddf = pd.read_csv(decomp_path, parse_dates=["date"]).set_index(
+                        "date"
+                    )
+
+        if ddf is not None and period is not None and len(ddf) >= 2 * period:
+            seasonal = ddf["seasonal"]
+            resid = ddf["resid"]
+            seasonal_amp = seasonal.max() - seasonal.min()
+            resid_rms = np.sqrt((resid**2).mean())
+            if not seasonal.empty:
+                idx = seasonal.idxmax()
+                if isinstance(idx, Timestamp):
+                    peak_month = idx.strftime("%Y-%m")
+                else:
+                    peak_month = str(idx)
 
         # trend via Sen's slope on decomposed trend component
         sen_slope = np.nan
         p_value = np.nan
         trend_change = np.nan
-        if (
-            decomp_dir
-            and decomp_path.exists()
-            and period is not None
-            and len(ddf) >= 2 * period
-        ):
-            # use ddf from above
+        if ddf is not None and period is not None and len(ddf) >= 2 * period:
             trend_series = ddf["trend"].dropna()
             if not trend_series.empty:
-                # time in years since start of trend_series
                 t = (trend_series.index - trend_series.index[0]).days / 365.25
                 sen_slope, _, _, _ = theilslopes(trend_series.values, t)
                 _, p_value = kendalltau(t, trend_series.values)

--- a/verdesat/webapp/services/compute.py
+++ b/verdesat/webapp/services/compute.py
@@ -61,8 +61,9 @@ def _read_remote_raster(key: str, geom: BaseGeometry | None = None) -> np.ndarra
     try:
         with rasterio.open(url) as src:
             if geom is not None:
-                arr, _ = rio_mask(src, [mapping(geom)], crop=True, nodata=np.nan)
-                data = arr[0]
+                arr, _ = rio_mask(src, [mapping(geom)], crop=True, filled=False)
+                data = arr[0].astype(float)
+                data[arr.mask[0]] = np.nan
             else:
                 arr = src.read(1, masked=True).astype(float)
                 data = arr.filled(np.nan)

--- a/verdesat/webapp/services/compute.py
+++ b/verdesat/webapp/services/compute.py
@@ -19,7 +19,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import rasterio
-from rasterio import mask as rio_mask
+from rasterio.mask import mask as rio_mask
 import streamlit as st
 from shapely.geometry import mapping
 from shapely.geometry.base import BaseGeometry

--- a/verdesat/webapp/services/compute.py
+++ b/verdesat/webapp/services/compute.py
@@ -47,6 +47,7 @@ CONFIG = ConfigManager(
     str(Path(__file__).resolve().parents[2] / "resources" / "webapp.toml")
 )
 REDIS_URL = CONFIG.get("cache", {}).get("redis_url")
+CACHE_VERSION = "2"  # bump to invalidate incompatible cached results
 
 
 def _read_remote_raster(key: str, geom: BaseGeometry | None = None) -> np.ndarray:
@@ -160,7 +161,7 @@ class ComputeService:
         logger.info(
             "compute demo metrics for AOI %s (%s-%s)", aoi_id, start_year, end_year
         )
-        cache_key = f"demo_{aoi_id}_{start_year}_{end_year}"
+        cache_key = f"demo_{CACHE_VERSION}_{aoi_id}_{start_year}_{end_year}"
         cached = _load_cache(self.storage, cache_key)
         if cached is not None:
             logger.info("demo metrics cache hit for AOI %s", aoi_id)
@@ -276,7 +277,7 @@ class ComputeService:
         logger.info(
             "compute live metrics for uploaded AOI(s) (%s-%s)", start_year, end_year
         )
-        cache_key = f"live_{_hash_gdf(gdf)}_{start_year}_{end_year}"
+        cache_key = f"live_{CACHE_VERSION}_{_hash_gdf(gdf)}_{start_year}_{end_year}"
         cached = _load_cache(self.storage, cache_key)
         if cached is not None:
             logger.info("live metrics cache hit")


### PR DESCRIPTION
## Summary
- streamline raster access by reading only AOI windows
- eliminate temp CSV files in favor of in-memory buffers
- run NDVI/MSAVI computations in parallel and expand stats API for buffers

## Testing
- `black .`
- `mypy .`
- `pytest -q` *(fails: ImportError: numpy.core.multiarray failed to import)*
- `python - <<'PY' ...` (benchmark script)

------
https://chatgpt.com/codex/tasks/task_e_688d4771b25483219c16f83bc7046cb4