### PR TITLE
feat: add project model and tests

### DIFF
--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+from verdesat.core.config import ConfigManager
+from verdesat.project.project import Project
+
+
+def _geojson() -> dict:
+    return {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"id": 1},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0]]
+                    ],
+                },
+            },
+            {
+                "type": "Feature",
+                "properties": {"id": 2},
+                "geometry": {
+                    "type": "Polygon",
+                    "coordinates": [
+                        [[1.0, 1.0], [1.0, 2.0], [2.0, 2.0], [2.0, 1.0], [1.0, 1.0]]
+                    ],
+                },
+            },
+        ],
+    }
+
+
+def test_from_geojson_builds_aois() -> None:
+    config = ConfigManager()
+    project = Project.from_geojson("Demo", "Client", _geojson(), config)
+    assert project.name == "Demo"
+    assert project.customer == "Client"
+    assert len(project.aois) == 2
+    assert project.rasters == {}
+    assert project.metrics == {}
+
+
+def test_attach_rasters() -> None:
+    config = ConfigManager()
+    project = Project.from_geojson("Demo", "Client", _geojson(), config)
+    project.attach_rasters(
+        {"1": "a_ndvi.tif"}, {"1": "a_msavi.tif", "2": "b_msavi.tif"}
+    )
+    assert project.rasters["1"]["ndvi"] == "a_ndvi.tif"
+    assert project.rasters["1"]["msavi"] == "a_msavi.tif"
+    assert project.rasters["2"]["msavi"] == "b_msavi.tif"
+    assert "ndvi" not in project.rasters["2"]
+
+
+def test_attach_metrics() -> None:
+    config = ConfigManager()
+    project = Project.from_geojson("Demo", "Client", _geojson(), config)
+    project.attach_metrics({"biodiv": 0.5, "vi": 0.7})
+    assert project.metrics["biodiv"] == 0.5
+    assert project.metrics["vi"] == 0.7

--- a/verdesat/project/project.py
+++ b/verdesat/project/project.py
@@ -1,14 +1,83 @@
-"""Module defining the VerdeSatProject class for managing client projects with multiple AOIs,
-handling data ingestion, processing, and visualization."""
+"""Project models for managing client projects and their AOIs."""
 
-from typing import List, Literal
-from verdesat.geo.aoi import AOI
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import logging
+from typing import Any, Dict, List, Literal
+
+from verdesat.analytics.timeseries import TimeSeries
 from verdesat.core.config import ConfigManager
-from verdesat.ingestion.vector_preprocessor import VectorPreprocessor
+from verdesat.core.logger import Logger
+from verdesat.core.storage import StorageAdapter
+from verdesat.geo.aoi import AOI
 from verdesat.ingestion import create_ingestor
 from verdesat.ingestion.sensorspec import SensorSpec
-from verdesat.analytics.timeseries import TimeSeries
+from verdesat.ingestion.vector_preprocessor import VectorPreprocessor
 from verdesat.visualization.visualizer import Visualizer
+
+
+@dataclass
+class Project:
+    """Lightweight project model holding AOIs and related artefacts."""
+
+    name: str
+    customer: str
+    aois: List[AOI]
+    config: ConfigManager
+    storage: StorageAdapter | None = None
+    logger: logging.Logger = field(default_factory=lambda: Logger.get_logger(__name__))
+    rasters: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    metrics: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_geojson(
+        cls,
+        name: str,
+        customer: str,
+        geojson: Dict[str, Any],
+        config: ConfigManager,
+        *,
+        storage: StorageAdapter | None = None,
+        logger: logging.Logger | None = None,
+    ) -> "Project":
+        """Construct a project from a GeoJSON feature collection."""
+
+        log = logger or Logger.get_logger(__name__)
+        id_col = config.get("id_col", "id")
+        aois = AOI.from_geojson(geojson, id_col=id_col)
+        log.debug("Loaded %s AOIs from GeoJSON", len(aois))
+        return cls(
+            name=name,
+            customer=customer,
+            aois=aois,
+            config=config,
+            storage=storage,
+            logger=log,
+        )
+
+    def attach_rasters(
+        self,
+        ndvi_paths: Dict[str, str],
+        msavi_paths: Dict[str, str],
+    ) -> None:
+        """Attach NDVI and MSAVI rasters to AOIs by their identifier."""
+        self.logger.debug(
+            "Attaching rasters: %s NDVI, %s MSAVI", len(ndvi_paths), len(msavi_paths)
+        )
+        id_col = self.config.get("id_col", "id")
+        for aoi in self.aois:
+            aoi_id = str(aoi.static_props.get(id_col))
+            entry = self.rasters.setdefault(aoi_id, {})
+            if aoi_id in ndvi_paths:
+                entry["ndvi"] = ndvi_paths[aoi_id]
+            if aoi_id in msavi_paths:
+                entry["msavi"] = msavi_paths[aoi_id]
+
+    def attach_metrics(self, metrics: Dict[str, Any]) -> None:
+        """Store computed metrics for the project."""
+        self.logger.debug("Attaching metrics: %s", list(metrics.keys()))
+        self.metrics.update(metrics)
 
 
 class VerdeSatProject:


### PR DESCRIPTION
## Summary
- add Project dataclass with GeoJSON loading and raster/metric attachment
- cover project model with unit tests

## Testing
- `black tests/project/test_project.py`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e8de2b99c83219494463ac767839a