### PR TITLE
fix: preserve map view between reruns

### DIFF
--- a/tests/webapp/test_map_widget.py
+++ b/tests/webapp/test_map_widget.py
@@ -24,3 +24,10 @@ def test_local_overlay(tmp_path):
     overlay = map_widget._local_overlay(str(path))
     assert overlay.url.startswith("data:image/png;base64,")
     assert overlay.bounds == [[0.0, 0.0], [2.0, 2.0]]
+
+
+def test_resolve_cog_path_relative():
+    rel = "resources/NDVI_1_2024-01-01.tif"
+    resolved = map_widget._resolve_cog_path(rel)
+    assert resolved is not None
+    assert resolved.exists()

--- a/verdesat/webapp/app.py
+++ b/verdesat/webapp/app.py
@@ -134,6 +134,8 @@ if st.sidebar.button("Load demo project"):
     st.session_state["run_requested"] = False
     # Drop any cached map from a previous project
     st.session_state.pop("main_map", None)
+    st.session_state.pop("map_obj", None)
+    st.session_state.pop("map_layers_key", None)
 
 if uploaded_file is not None:
     # Create / refresh the project only when the user selects
@@ -147,6 +149,8 @@ if uploaded_file is not None:
         st.session_state["uploaded_filename"] = uploaded_file.name
         st.session_state["run_requested"] = False
         st.session_state.pop("main_map", None)
+        st.session_state.pop("map_obj", None)
+        st.session_state.pop("map_layers_key", None)
 
 if _demo_cfg and st.session_state.get("project") and not uploaded_file:
     st.session_state["run_requested"] = True

--- a/verdesat/webapp/app.py
+++ b/verdesat/webapp/app.py
@@ -132,9 +132,7 @@ uploaded_file = st.sidebar.file_uploader("GeoJSON Project", type="geojson")
 if st.sidebar.button("Load demo project"):
     st.session_state["project"] = load_demo_project()
     st.session_state["run_requested"] = False
-    # Drop any saved map view from a previous project
-    st.session_state.pop("map_center", None)
-    st.session_state.pop("map_zoom", None)
+    # Drop any cached map from a previous project
     st.session_state.pop("main_map", None)
 
 if uploaded_file is not None:
@@ -148,8 +146,6 @@ if uploaded_file is not None:
         )
         st.session_state["uploaded_filename"] = uploaded_file.name
         st.session_state["run_requested"] = False
-        st.session_state.pop("map_center", None)
-        st.session_state.pop("map_zoom", None)
         st.session_state.pop("main_map", None)
 
 if _demo_cfg and st.session_state.get("project") and not uploaded_file:

--- a/verdesat/webapp/components/map_widget.py
+++ b/verdesat/webapp/components/map_widget.py
@@ -95,7 +95,11 @@ def display_map(aoi_gdf, rasters: Mapping[str, Mapping[str, str]]) -> None:
         cached_map, folium.Map
     ):
         bounds_arr = aoi_gdf.total_bounds.reshape(2, 2)
-        m = folium.Map(tiles="CartoDB positron")
+        centre = [
+            (bounds_arr[0][1] + bounds_arr[1][1]) / 2,
+            (bounds_arr[0][0] + bounds_arr[1][0]) / 2,
+        ]
+        m = folium.Map(location=centre, zoom_start=13, tiles="CartoDB positron")
 
         folium.GeoJson(
             json.loads(aoi_gdf.to_json()),
@@ -139,4 +143,11 @@ def display_map(aoi_gdf, rasters: Mapping[str, Mapping[str, str]]) -> None:
         st.session_state["map_obj"] = m
         st.session_state["map_layers_key"] = layers_key
 
-    st_folium(st.session_state["map_obj"], width="100%", height=500, key="main_map")
+    state = st_folium(
+        st.session_state["map_obj"], width="100%", height=500, key="main_map"
+    )
+    if state and state.get("center"):
+        m = st.session_state["map_obj"]
+        m.location = [state["center"]["lat"], state["center"]["lng"]]
+        if "zoom" in state:
+            m.options["zoom"] = state["zoom"]

--- a/verdesat/webapp/components/map_widget.py
+++ b/verdesat/webapp/components/map_widget.py
@@ -89,9 +89,10 @@ def display_map(aoi_gdf, rasters: Mapping[str, Mapping[str, str]]) -> None:
         (aoi_gdf.to_json() + json.dumps(rasters, sort_keys=True)).encode("utf-8")
     ).hexdigest()
 
-    if (
-        st.session_state.get("map_layers_key") != layers_key
-        or "main_map" not in st.session_state
+    cached_map = st.session_state.get("map_obj")
+
+    if st.session_state.get("map_layers_key") != layers_key or not isinstance(
+        cached_map, folium.Map
     ):
         bounds_arr = aoi_gdf.total_bounds.reshape(2, 2)
         m = folium.Map(tiles="CartoDB positron")
@@ -135,7 +136,7 @@ def display_map(aoi_gdf, rasters: Mapping[str, Mapping[str, str]]) -> None:
 
         m.fit_bounds(bounds_arr.tolist())
 
-        st.session_state["main_map"] = m
+        st.session_state["map_obj"] = m
         st.session_state["map_layers_key"] = layers_key
 
-    st_folium(st.session_state["main_map"], width="100%", height=500, key="main_map")
+    st_folium(st.session_state["map_obj"], width="100%", height=500, key="main_map")


### PR DESCRIPTION
## Summary
- cache folium map to prevent view resets between reruns
- remove stale map state handling when switching projects
- handle fully unmasked rasters when generating overlays

## Testing
- `black verdesat/webapp/components/map_widget.py verdesat/webapp/app.py`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890646766f483219244c9c93d25fd48