### PR TITLE
fix: remove Streamlit caching from impure functions

### DIFF
--- a/tests/webapp/test_project_compute_service.py
+++ b/tests/webapp/test_project_compute_service.py
@@ -186,7 +186,6 @@ def test_compute_uses_cache(monkeypatch):
             }
         },
     )
-    project_compute.ProjectComputeService.compute.clear()
     monkeypatch.setattr(project_compute, "_load_cache", lambda storage, key: cached)
 
     result = svc.compute(project, date(2024, 1, 1), date(2024, 12, 31))
@@ -212,7 +211,6 @@ def test_compute_recomputes_legacy_cache(monkeypatch):
         pd.DataFrame(),
         pd.DataFrame(),
     )
-    project_compute.ProjectComputeService.compute.clear()
     monkeypatch.setattr(
         project_compute, "_load_cache", lambda storage, key: legacy_cached
     )

--- a/verdesat/webapp/app.py
+++ b/verdesat/webapp/app.py
@@ -46,7 +46,6 @@ project_compute = ProjectComputeService(
 )
 
 
-@st.cache_data
 def load_demo_project() -> Project:
     """Load demo project from bundled GeoJSON and attach demo rasters."""
 
@@ -70,7 +69,6 @@ def load_demo_project() -> Project:
     return project
 
 
-@st.cache_data(hash_funcs={Project: project_compute._hash_project})
 def compute_project(project: Project, start_year: int, end_year: int) -> tuple[
     pd.DataFrame,
     pd.DataFrame,
@@ -82,8 +80,8 @@ def compute_project(project: Project, start_year: int, end_year: int) -> tuple[
     """Compute metrics and vegetation indices for *project*.
 
     The returned tuple includes per-AOI raster paths and metrics so callers can
-    reattach them to freshly initialised :class:`Project` instances on cache
-    hits where the function body is not executed.
+    reattach them to freshly initialised :class:`Project` instances when
+    rebuilding state from persisted caches.
     """
 
     metrics_df, ndvi_df, msavi_df = project_compute.compute(

--- a/verdesat/webapp/components/charts.py
+++ b/verdesat/webapp/components/charts.py
@@ -9,14 +9,12 @@ import streamlit as st
 from verdesat.webapp.services.r2 import signed_url
 
 
-@st.cache_data
 def load_ndvi_decomposition(aoi_id: int) -> pd.DataFrame:
     """Load NDVI decomposition CSV for ``aoi_id`` from R2."""
     url = signed_url(f"resources/decomp/{aoi_id}_decomposition.csv")
     return pd.read_csv(url, parse_dates=["date"])
 
 
-@st.cache_data
 def load_msavi_timeseries() -> pd.DataFrame:
     """Load MSAVI time series CSV from R2."""
     url = signed_url("resources/msavi.csv")

--- a/verdesat/webapp/services/project_compute.py
+++ b/verdesat/webapp/services/project_compute.py
@@ -18,7 +18,6 @@ from typing import Any, Dict, Tuple, Protocol, cast
 
 import geopandas as gpd
 import pandas as pd
-import streamlit as st
 from shapely.geometry import mapping
 
 try:  # pragma: no cover - optional dependency
@@ -142,7 +141,6 @@ def _stats_row_to_dict(row: pd.Series, index: str) -> dict[str, float | str]:
     return stats
 
 
-@st.cache_data
 def _ndvi_stats(
     aoi_path: str, start_year: int, end_year: int
 ) -> tuple[dict[str, float | str], pd.DataFrame]:
@@ -200,7 +198,6 @@ def _ndvi_stats(
     return stats, decomp_df[["date", "observed", "trend", "seasonal"]]
 
 
-@st.cache_data
 def _msavi_stats(
     aoi_path: str, start_year: int, end_year: int
 ) -> tuple[dict[str, float | str], pd.DataFrame]:
@@ -274,25 +271,13 @@ class ProjectComputeService:
         return self._hash_project(project)
 
     # ------------------------------------------------------------------
-    @st.cache_data(
-        show_spinner=False,
-        hash_funcs={
-            Project: _hash_project,
-            MSAService: lambda _svc: 0,
-            BScoreCalculator: lambda _svc: 0,
-            StorageAdapter: lambda _svc: 0,
-            ChipService: lambda _svc: 0,
-            ConfigManager: lambda _svc: 0,
-            Logger: lambda _svc: 0,
-        },
-    )
     def compute(
         _self, project: Project, start: date, end: date
     ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
         """Compute biodiversity metrics and vegetation indices for *project*.
 
-        Results are cached both in-memory via Streamlit and persisted via
-        :func:`_persist_cache` to avoid recomputation.
+        Results are persisted via :func:`_persist_cache` to avoid
+        recomputation.
         """
 
         cache_key = f"project_{_self._project_hash(project)}_{start}_{end}"


### PR DESCRIPTION
## Summary
- remove Streamlit cache decorators from impure NDVI/MSAVI helpers and project compute service to rely on persisted caching
- drop Streamlit caching from webapp project loaders/wrappers so logs stream correctly
- adjust tests for new caching approach

## Testing
- `black .`
- `mypy verdesat`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891d99765d08321bc37c9af67bdb0d8