### PR TITLE
feat: integrate streamlit app styling

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,6 @@
+[theme]
+primaryColor = "#2B6E3F"
+backgroundColor = "#FFFFFF"
+secondaryBackgroundColor = "#14213D"
+textColor = "#14213D"
+font = "sans serif"

--- a/verdesat/webapp/app.py
+++ b/verdesat/webapp/app.py
@@ -29,6 +29,12 @@ from verdesat.webapp.services.chip_service import EEChipServiceAdapter
 from verdesat.webapp.services.project_compute import ProjectComputeService
 from verdesat.webapp.services.r2 import signed_url
 from verdesat.webapp.services.exports import export_project_pdf
+from verdesat.webapp.themes import (
+    inject_style,
+    render_hero,
+    render_navbar,
+    section,
+)
 
 logger = Logger.get_logger(__name__)
 
@@ -119,6 +125,9 @@ def report_controls(
 
 # ---- Page config -----------------------------------------------------------
 st.set_page_config(page_title="VerdeSat B-Score", page_icon="🌳", layout="wide")
+inject_style()
+render_navbar()
+render_hero()
 
 # ---- Sidebar ---------------------------------------------------------------
 st.sidebar.header("VerdeSat B-Score v0.1")
@@ -203,11 +212,9 @@ if _demo_cfg and st.session_state.get("project") and not uploaded_file:
 project: Project | None = st.session_state.get("project")
 
 # ---- Main canvas -----------------------------------------------------------
-st.title("VerdeSat Biodiversity Dashboard")
-col1, col2 = st.columns([3, 1])
-
 if project is None:
-    st.info("Upload a GeoJSON file or load the demo project to begin.")
+    with section():
+        st.info("Upload a GeoJSON file or load the demo project to begin.")
 elif st.session_state.get("run_requested"):
     (
         metrics_df,
@@ -218,14 +225,10 @@ elif st.session_state.get("run_requested"):
         metrics_by_id,
     ) = compute_project(project, start_year, end_year)
 
-    # Reattach artefacts when results are served from cache.
     project.attach_rasters(ndvi_paths, msavi_paths)
     project.attach_metrics(metrics_by_id)
-
-    # Clear the flag so slider tweaks alone don’t recompute
     st.session_state["run_requested"] = False
 
-    # Cache results in session_state so they persist on subsequent reruns
     gdf = gpd.GeoDataFrame(
         [{**a.static_props, "geometry": a.geometry} for a in project.aois],
         crs="EPSG:4326",
@@ -242,32 +245,36 @@ elif st.session_state.get("run_requested"):
         "metrics": metrics,
     }
 
-    with col1:
-        display_map(gdf, project.rasters)
-    with col2:
-        bscore_gauge(metrics.bscore)
+    with section():
+        col1, col2 = st.columns([3, 1])
+        with col1:
+            display_map(gdf, project.rasters)
+        with col2:
+            bscore_gauge(metrics.bscore)
 
-    st.markdown("---")
-    display_metrics(metrics)
-    st.dataframe(metrics_df)
-    report_controls(metrics_df, project, start_year, end_year)
+    with section(alt=True):
+        display_metrics(metrics)
+        st.dataframe(metrics_df)
+        report_controls(metrics_df, project, start_year, end_year)
 
-    st.markdown("---")
-    tab_obs, tab_trend, tab_season, tab_msavi = st.tabs(
-        ["NDVI Observed", "NDVI Trend", "NDVI Seasonal", "MSAVI YE"]
-    )
-    with tab_obs:
-        ndvi_component_chart(
-            ndvi_df, "observed", start_year=start_year, end_year=end_year
+    with section():
+        tab_obs, tab_trend, tab_season, tab_msavi = st.tabs(
+            ["NDVI Observed", "NDVI Trend", "NDVI Seasonal", "MSAVI YE"]
         )
-    with tab_trend:
-        ndvi_component_chart(ndvi_df, "trend", start_year=start_year, end_year=end_year)
-    with tab_season:
-        ndvi_component_chart(
-            ndvi_df, "seasonal", start_year=start_year, end_year=end_year
-        )
-    with tab_msavi:
-        msavi_bar_chart_all(msavi_df, start_year=start_year, end_year=end_year)
+        with tab_obs:
+            ndvi_component_chart(
+                ndvi_df, "observed", start_year=start_year, end_year=end_year
+            )
+        with tab_trend:
+            ndvi_component_chart(
+                ndvi_df, "trend", start_year=start_year, end_year=end_year
+            )
+        with tab_season:
+            ndvi_component_chart(
+                ndvi_df, "seasonal", start_year=start_year, end_year=end_year
+            )
+        with tab_msavi:
+            msavi_bar_chart_all(msavi_df, start_year=start_year, end_year=end_year)
 elif "results" in st.session_state:
     res = st.session_state["results"]
     gdf = res["gdf"]
@@ -276,31 +283,36 @@ elif "results" in st.session_state:
     msavi_df = res["msavi_df"]
     metrics = res["metrics"]
 
-    with col1:
-        display_map(gdf, project.rasters)
-    with col2:
-        bscore_gauge(metrics.bscore)
+    with section():
+        col1, col2 = st.columns([3, 1])
+        with col1:
+            display_map(gdf, project.rasters)
+        with col2:
+            bscore_gauge(metrics.bscore)
 
-    st.markdown("---")
-    display_metrics(metrics)
-    st.dataframe(metrics_df)
-    report_controls(metrics_df, project, start_year, end_year)
+    with section(alt=True):
+        display_metrics(metrics)
+        st.dataframe(metrics_df)
+        report_controls(metrics_df, project, start_year, end_year)
 
-    st.markdown("---")
-    tab_obs, tab_trend, tab_season, tab_msavi = st.tabs(
-        ["NDVI Observed", "NDVI Trend", "NDVI Seasonal", "MSAVI YE"]
-    )
-    with tab_obs:
-        ndvi_component_chart(
-            ndvi_df, "observed", start_year=start_year, end_year=end_year
+    with section():
+        tab_obs, tab_trend, tab_season, tab_msavi = st.tabs(
+            ["NDVI Observed", "NDVI Trend", "NDVI Seasonal", "MSAVI YE"]
         )
-    with tab_trend:
-        ndvi_component_chart(ndvi_df, "trend", start_year=start_year, end_year=end_year)
-    with tab_season:
-        ndvi_component_chart(
-            ndvi_df, "seasonal", start_year=start_year, end_year=end_year
-        )
-    with tab_msavi:
-        msavi_bar_chart_all(msavi_df, start_year=start_year, end_year=end_year)
+        with tab_obs:
+            ndvi_component_chart(
+                ndvi_df, "observed", start_year=start_year, end_year=end_year
+            )
+        with tab_trend:
+            ndvi_component_chart(
+                ndvi_df, "trend", start_year=start_year, end_year=end_year
+            )
+        with tab_season:
+            ndvi_component_chart(
+                ndvi_df, "seasonal", start_year=start_year, end_year=end_year
+            )
+        with tab_msavi:
+            msavi_bar_chart_all(msavi_df, start_year=start_year, end_year=end_year)
 else:
-    st.info("Adjust parameters, then press **Run analysis**.")
+    with section():
+        st.info("Adjust parameters, then press **Run analysis**.")

--- a/verdesat/webapp/themes/__init__.py
+++ b/verdesat/webapp/themes/__init__.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+"""Styling utilities for the Streamlit web application."""
+
+from contextlib import contextmanager
+from typing import Iterator
+
+import streamlit as st
+
+LOGO_URL = "https://www.verdesat.com/favicon.svg"
+HERO_URL = "https://www.verdesat.com/images/hero-sat-screen.webp"
+DEMO_URL = "https://calendly.com/andreydara/meet-verdesat"
+REPORT_URL = "https://www.verdesat.com/sample-report.pdf"
+
+
+def inject_style() -> None:
+    """Inject global CSS rules and fonts."""
+    st.markdown(
+        f"""
+        <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Montserrat:wght@400;600;700&display=swap');
+        html, body, [class*='css'] {{
+            font-family: 'Inter', sans-serif;
+        }}
+        h1, h2, h3, h4, h5 {{
+            font-family: 'Montserrat', sans-serif;
+            font-weight: 600;
+        }}
+        #MainMenu {{visibility: hidden;}}
+        footer {{visibility: hidden;}}
+        header {{visibility: hidden;}}
+        .stButton>button {{
+            background-color: #2B6E3F;
+            color: #FFFFFF;
+            border-radius: 9999px;
+            border: 1px solid #6EE7B7;
+        }}
+        .vs-btn {{
+            background-color: #2B6E3F;
+            color: #6EE7B7;
+            padding: 0.5rem 1.5rem;
+            border-radius: 9999px;
+            text-decoration: none;
+        }}
+        .vs-btn:hover {{opacity: 0.9;}}
+        .vs-navbar {{
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            z-index: 999;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0.5rem 1rem;
+            background-color: #FFFFFF;
+        }}
+        .vs-navbar a {{
+            margin-left: 1rem;
+            text-decoration: none;
+            color: #14213D;
+        }}
+        .vs-hero {{
+            margin-top: 60px;
+            position: relative;
+            height: 300px;
+            background: linear-gradient(180deg, rgba(19,78,74,0.5), rgba(19,78,74,0.5) 50%, #134E4A), url('{HERO_URL}') center/cover no-repeat;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            text-align: center;
+        }}
+        .vs-section {{
+            background-color: #FFFFFF;
+            padding: 2rem 1rem;
+        }}
+        .vs-section-alt {{
+            background-color: #F8F9FA;
+            padding: 2rem 1rem;
+        }}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_navbar() -> None:
+    """Render the top navigation bar."""
+    st.markdown(
+        f"""
+        <nav class=\"vs-navbar\">
+            <div>
+                <a href=\"https://www.verdesat.com\"><img src=\"{LOGO_URL}\" height=\"32\"/></a>
+            </div>
+            <div>
+                <a href=\"{DEMO_URL}\" target=\"_blank\">Demo</a>
+                <a href=\"{REPORT_URL}\" target=\"_blank\">Sample Report</a>
+            </div>
+        </nav>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_hero() -> None:
+    """Render the hero section with call to actions."""
+    st.markdown(
+        f"""
+        <section class=\"vs-hero\">
+            <h1>VerdeSat Biodiversity Dashboard</h1>
+            <div style=\"margin-top:1rem;\">
+                <a class=\"vs-btn\" href=\"{DEMO_URL}\" target=\"_blank\">Book a Demo</a>
+                <a class=\"vs-btn\" href=\"{REPORT_URL}\" target=\"_blank\" style=\"margin-left:0.5rem;\">Sample Report</a>
+            </div>
+        </section>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+@contextmanager
+def section(alt: bool = False) -> Iterator[None]:
+    """Context manager for content sections with alternating backgrounds."""
+    cls = "vs-section-alt" if alt else "vs-section"
+    st.markdown(f"<div class='{cls}'>", unsafe_allow_html=True)
+    try:
+        yield
+    finally:
+        st.markdown("</div>", unsafe_allow_html=True)
+
+
+__all__ = ["inject_style", "render_navbar", "render_hero", "section"]


### PR DESCRIPTION
## Summary
- theme streamlit app to match landing page
- add navigation bar, hero banner and call-to-action links
- organize main sections with alternating backgrounds

## Testing
- `black .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891fcd2e05883219d79a9c2d605f451