### PR TITLE
feat: apply VerdeSat theme to webapp

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,6 @@
+[theme]
+primaryColor="#2B6E3F"
+backgroundColor="#FFFFFF"
+secondaryBackgroundColor="#F8F9FA"
+textColor="#14213D"
+font="sans serif"

--- a/verdesat/webapp/app.py
+++ b/verdesat/webapp/app.py
@@ -25,6 +25,11 @@ from verdesat.webapp.components.charts import (
 )
 from verdesat.webapp.components.kpi_cards import Metrics, bscore_gauge, display_metrics
 from verdesat.webapp.components.map_widget import display_map
+from verdesat.webapp.components.layout import (
+    apply_theme,
+    render_hero,
+    render_navbar,
+)
 from verdesat.webapp.services.chip_service import EEChipServiceAdapter
 from verdesat.webapp.services.project_compute import ProjectComputeService
 from verdesat.webapp.services.r2 import signed_url
@@ -119,6 +124,9 @@ def report_controls(
 
 # ---- Page config -----------------------------------------------------------
 st.set_page_config(page_title="VerdeSat B-Score", page_icon="🌳", layout="wide")
+apply_theme()
+render_navbar()
+render_hero("VerdeSat Biodiversity Dashboard")
 
 # ---- Sidebar ---------------------------------------------------------------
 st.sidebar.header("VerdeSat B-Score v0.1")
@@ -203,7 +211,6 @@ if _demo_cfg and st.session_state.get("project") and not uploaded_file:
 project: Project | None = st.session_state.get("project")
 
 # ---- Main canvas -----------------------------------------------------------
-st.title("VerdeSat Biodiversity Dashboard")
 col1, col2 = st.columns([3, 1])
 
 if project is None:

--- a/verdesat/webapp/components/layout.py
+++ b/verdesat/webapp/components/layout.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Layout and theming helpers for the Streamlit dashboard."""
+
+import streamlit as st
+
+NAV_LINKS: tuple[tuple[str, str], ...] = (
+    ("Home", "https://www.verdesat.com"),
+    ("Demo", "https://calendly.com/andreydara/meet-verdesat"),
+    ("Docs", "https://docs.verdesat.com"),
+)
+
+
+def apply_theme() -> None:
+    """Inject fonts, colors, and base CSS matching VerdeSat branding."""
+
+    st.markdown(
+        """
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&family=Montserrat:wght@400;600;700&display=swap');
+        html, body, [class*="css"] {font-family: 'Inter', sans-serif; color: #14213D;}
+        h1, h2, h3, h4, h5 {font-family: 'Montserrat', sans-serif; font-weight: 600; color: #14213D;}
+        #MainMenu {visibility: hidden;}
+        footer {visibility: hidden;}
+        header {visibility: hidden;}
+        .vs-navbar {position: fixed; top: 0; left: 0; right: 0; background: #14213D; height: 56px; padding: 8px 24px; display: flex; align-items: center; z-index: 1000;}
+        .vs-navbar img {height: 32px;}
+        .vs-navbar a {color: #FFFFFF; margin-left: 24px; text-decoration: none; font-family: 'Montserrat', sans-serif;}
+        .vs-navbar a:hover {color: #6EE7B7;}
+        .vs-hero {margin-top: 56px; background: linear-gradient(180deg, rgba(19,78,74,0.5), rgba(19,78,74,0.5) 50%, #134E4A), url('https://www.verdesat.com/images/hero-sat-screen.webp'); background-size: cover; background-position: center; padding: 96px 24px; text-align: center; color: #FFFFFF;}
+        div.block-container > div:nth-child(even):not(.vs-hero) {background-color: #FFFFFF;}
+        div.block-container > div:nth-child(odd):not(.vs-hero) {background-color: #F8F9FA;}
+        div.block-container > div:not(.vs-hero) {padding: 32px 24px;}
+        .stButton>button, .stDownloadButton>button {background-color: #2B6E3F; color: #FFFFFF; border-radius: 9999px;}
+        .stButton>button:hover, .stDownloadButton>button:hover {color: #6EE7B7;}
+        @media (max-width: 600px) {
+            .vs-navbar {flex-wrap: wrap; height: auto; padding: 8px 16px;}
+            .vs-navbar a {margin-left: 16px; margin-top: 4px;}
+            .vs-hero {padding: 64px 16px;}
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_navbar() -> None:
+    """Render the fixed top navigation bar."""
+
+    links = "".join(
+        f'<a href="{url}" target="_blank" rel="noopener noreferrer">{label}</a>'
+        for label, url in NAV_LINKS
+    )
+    st.markdown(
+        f"""
+        <nav class="vs-navbar">
+            <img src="https://www.verdesat.com/favicon.svg" alt="VerdeSat logo" />
+            {links}
+        </nav>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def render_hero(title: str) -> None:
+    """Display a full-width hero banner with ``title``."""
+
+    st.markdown(
+        f"""
+        <section class="vs-hero">
+            <h1>{title}</h1>
+        </section>
+        """,
+        unsafe_allow_html=True,
+    )

--- a/verdesat/webapp/components/layout.py
+++ b/verdesat/webapp/components/layout.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import streamlit as st
 
 NAV_LINKS: tuple[tuple[str, str], ...] = (
+    ("Book a Demo", "https://calendly.com/andreydara/meet-verdesat"),
     ("Home", "https://www.verdesat.com"),
-    ("Demo", "https://calendly.com/andreydara/meet-verdesat"),
-    ("Docs", "https://docs.verdesat.com"),
 )
 
 
@@ -25,10 +24,16 @@ def apply_theme() -> None:
         #MainMenu {visibility: hidden;}
         footer {visibility: hidden;}
         header {visibility: hidden;}
-        .vs-navbar {position: fixed; top: 0; left: 0; right: 0; background: #14213D; height: 56px; padding: 8px 24px; display: flex; align-items: center; z-index: 1000;}
-        .vs-navbar img {height: 32px;}
-        .vs-navbar a {color: #FFFFFF; margin-left: 24px; text-decoration: none; font-family: 'Montserrat', sans-serif;}
-        .vs-navbar a:hover {color: #6EE7B7;}
+        .vs-navbar {position: fixed; top: 0; left: 0; right: 0; background: rgba(255,255,255,0.8); backdrop-filter: blur(6px); height: 56px; padding: 8px 24px; display: flex; align-items: center; z-index: 1000; box-shadow: 0 1px 2px rgba(0,0,0,0.05);}
+        .vs-navbar img {height: 32px; margin-right: 8px;}
+        .vs-navbar a {
+            color: #14213D;
+            margin-left: 24px;
+            text-decoration: none;
+            font-family: 'Montserrat', sans-serif;
+            font-weight: 600;
+        }
+        .vs-navbar a:hover {color: #2B6E3F;}
         .vs-hero {margin-top: 56px; background: linear-gradient(180deg, rgba(19,78,74,0.5), rgba(19,78,74,0.5) 50%, #134E4A), url('https://www.verdesat.com/images/hero-sat-screen.webp'); background-size: cover; background-position: center; padding: 96px 24px; text-align: center; color: #FFFFFF;}
         div.block-container > div:nth-child(even):not(.vs-hero) {background-color: #FFFFFF;}
         div.block-container > div:nth-child(odd):not(.vs-hero) {background-color: #F8F9FA;}
@@ -36,7 +41,7 @@ def apply_theme() -> None:
         .stButton>button, .stDownloadButton>button {background-color: #2B6E3F; color: #FFFFFF; border-radius: 9999px;}
         .stButton>button:hover, .stDownloadButton>button:hover {color: #6EE7B7;}
         @media (max-width: 600px) {
-            .vs-navbar {flex-wrap: wrap; height: auto; padding: 8px 16px;}
+            .vs-navbar {flex-wrap: wrap; height: auto; padding: 8px 16px; background: rgba(255,255,255,0.9);}
             .vs-navbar a {margin-left: 16px; margin-top: 4px;}
             .vs-hero {padding: 64px 16px;}
         }


### PR DESCRIPTION
## Summary
- integrate VerdeSat visual identity via global theme config
- add reusable layout helpers for fonts, navbar, hero banner, and button styling
- apply theme and branding to Streamlit app

## Testing
- `black .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68923590d25c8321a8ab32a62f58a491