### PR TITLE
feat(webapp): refine layout and navigation styling

### DIFF
--- a/verdesat/webapp/app.py
+++ b/verdesat/webapp/app.py
@@ -129,7 +129,7 @@ render_navbar()
 render_hero("VerdeSat Biodiversity Dashboard")
 
 # ---- Sidebar ---------------------------------------------------------------
-st.sidebar.header("VerdeSat B-Score v0.1")
+st.sidebar.header("VerdeSat B-Score v0.1.2")
 
 # ---- Dev log pane ---------------------------------------------------------
 
@@ -147,6 +147,47 @@ class StreamlitHandler(logging.Handler):
         self.container.code("\n".join(self.lines))
 
 
+# Initialise run flag before drawing controls
+if "run_requested" not in st.session_state:
+    st.session_state["run_requested"] = False
+
+if st.sidebar.button("Load demo project"):
+    st.session_state["project"] = load_demo_project()
+    st.session_state["run_requested"] = False
+    # Drop any cached map from a previous project
+    st.session_state.pop("main_map", None)
+    st.session_state.pop("map_obj", None)
+    st.session_state.pop("map_layers_key", None)
+
+start_year, end_year = st.sidebar.slider(
+    "Years",
+    2019,
+    2024,
+    value=(
+        int(_defaults.get("start_year", 2019)),
+        int(_defaults.get("end_year", 2024)),
+    ),
+)
+
+uploaded_file = st.sidebar.file_uploader("GeoJSON Project", type="geojson")
+if uploaded_file is not None:
+    # Create / refresh the project only when the user selects
+    # *a different* file. On normal reruns `uploaded_file` is the
+    # same  object and we must *not* wipe the run_requested flag.
+    if st.session_state.get("uploaded_filename") != uploaded_file.name:
+        geojson = json.load(uploaded_file)
+        st.session_state["project"] = Project.from_geojson(
+            "Uploaded Project", "Guest", geojson, CONFIG, storage=storage
+        )
+        st.session_state["uploaded_filename"] = uploaded_file.name
+        st.session_state["run_requested"] = False
+        st.session_state.pop("main_map", None)
+        st.session_state.pop("map_obj", None)
+        st.session_state.pop("map_layers_key", None)
+
+if st.sidebar.button("Run analysis"):
+    st.session_state["run_requested"] = True
+
 show_log = st.sidebar.checkbox("Show log pane")
 root_logger = logging.getLogger()
 existing_handler = cast(logging.Handler | None, st.session_state.get("log_handler"))
@@ -162,48 +203,6 @@ else:
     if existing_handler:
         root_logger.removeHandler(existing_handler)
         st.session_state.pop("log_handler")
-
-# --- Compute trigger --------------------------------------------------
-if "run_requested" not in st.session_state:
-    st.session_state["run_requested"] = False
-if st.sidebar.button("Run analysis"):
-    st.session_state["run_requested"] = True
-
-
-# --- Years Slider --------------------------------------------------
-start_year, end_year = st.sidebar.slider(
-    "Years",
-    2019,
-    2024,
-    value=(
-        int(_defaults.get("start_year", 2019)),
-        int(_defaults.get("end_year", 2024)),
-    ),
-)
-
-uploaded_file = st.sidebar.file_uploader("GeoJSON Project", type="geojson")
-if st.sidebar.button("Load demo project"):
-    st.session_state["project"] = load_demo_project()
-    st.session_state["run_requested"] = False
-    # Drop any cached map from a previous project
-    st.session_state.pop("main_map", None)
-    st.session_state.pop("map_obj", None)
-    st.session_state.pop("map_layers_key", None)
-
-if uploaded_file is not None:
-    # Create / refresh the project only when the user selects
-    # *a different* file. On normal reruns `uploaded_file` is the
-    # same  object and we must *not* wipe the run_requested flag.
-    if st.session_state.get("uploaded_filename") != uploaded_file.name:
-        geojson = json.load(uploaded_file)
-        st.session_state["project"] = Project.from_geojson(
-            "Uploaded Project", "Guest", geojson, CONFIG, storage=storage
-        )
-        st.session_state["uploaded_filename"] = uploaded_file.name
-        st.session_state["run_requested"] = False
-        st.session_state.pop("main_map", None)
-        st.session_state.pop("map_obj", None)
-        st.session_state.pop("map_layers_key", None)
 
 if _demo_cfg and st.session_state.get("project") and not uploaded_file:
     st.session_state["run_requested"] = True
@@ -256,10 +255,6 @@ elif st.session_state.get("run_requested"):
 
     st.markdown("---")
     display_metrics(metrics)
-    st.dataframe(metrics_df)
-    report_controls(metrics_df, project, start_year, end_year)
-
-    st.markdown("---")
     tab_obs, tab_trend, tab_season, tab_msavi = st.tabs(
         ["NDVI Observed", "NDVI Trend", "NDVI Seasonal", "MSAVI YE"]
     )
@@ -275,6 +270,8 @@ elif st.session_state.get("run_requested"):
         )
     with tab_msavi:
         msavi_bar_chart_all(msavi_df, start_year=start_year, end_year=end_year)
+    report_controls(metrics_df, project, start_year, end_year)
+    st.dataframe(metrics_df)
 elif "results" in st.session_state:
     res = st.session_state["results"]
     gdf = res["gdf"]
@@ -290,10 +287,6 @@ elif "results" in st.session_state:
 
     st.markdown("---")
     display_metrics(metrics)
-    st.dataframe(metrics_df)
-    report_controls(metrics_df, project, start_year, end_year)
-
-    st.markdown("---")
     tab_obs, tab_trend, tab_season, tab_msavi = st.tabs(
         ["NDVI Observed", "NDVI Trend", "NDVI Seasonal", "MSAVI YE"]
     )
@@ -309,5 +302,7 @@ elif "results" in st.session_state:
         )
     with tab_msavi:
         msavi_bar_chart_all(msavi_df, start_year=start_year, end_year=end_year)
+    report_controls(metrics_df, project, start_year, end_year)
+    st.dataframe(metrics_df)
 else:
     st.info("Adjust parameters, then press **Run analysis**.")

--- a/verdesat/webapp/components/layout.py
+++ b/verdesat/webapp/components/layout.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import streamlit as st
 
+# (label, url) pairs used to build the navbar. The "Book a Demo" link is
+# styled separately from the main site link.
 NAV_LINKS: tuple[tuple[str, str], ...] = (
     ("Book a Demo", "https://calendly.com/andreydara/meet-verdesat"),
     ("VerdeSat", "https://www.verdesat.com"),
@@ -26,15 +28,18 @@ def apply_theme() -> None:
         header {visibility: hidden;}
         .vs-navbar {position: fixed; top: 0; left: 0; right: 0; background: rgba(255,255,255,0.8); backdrop-filter: blur(6px); height: 56px; padding: 8px 24px; display: flex; align-items: center; z-index: 1000; box-shadow: 0 1px 2px rgba(0,0,0,0.05);}
         .vs-navbar img {height: 32px; margin-right: 8px;}
-        .vs-navbar a {
+        .vs-nav-links {margin-left: auto; display: flex; align-items: center;}
+        .vs-nav-links a {
             color: #14213D;
             margin-left: 24px;
             text-decoration: none;
             font-family: 'Montserrat', sans-serif;
             font-weight: 600;
         }
-        .vs-navbar a:hover {color: #2B6E3F;}
-        .vs-hero {margin-top: 56px; background: linear-gradient(180deg, rgba(19,78,74,0.5), rgba(19,78,74,0.5) 50%, #134E4A), url('https://www.verdesat.com/images/hero-sat-screen.webp'); background-size: cover; background-position: center; padding: 96px 24px; text-align: center; color: #FFFFFF;}
+        .vs-nav-links a.book-demo {color: #111827; font-weight: 400;}
+        .vs-nav-links a:hover {color: #2B6E3F;}
+        .vs-hero {background: linear-gradient(180deg, rgba(19,78,74,0.5), rgba(19,78,74,0.5) 50%, #134E4A), url('https://www.verdesat.com/images/hero-sat-screen.webp'); background-size: cover; background-position: center; padding: 96px 24px; text-align: center; color: #FFFFFF;}
+        div[data-testid="collapsedControl"] {top: 64px; z-index: 2000;}
         div.block-container > div:nth-child(even):not(.vs-hero) {background-color: #FFFFFF;}
         div.block-container > div:nth-child(odd):not(.vs-hero) {background-color: #F8F9FA;}
         div.block-container > div:not(.vs-hero) {padding: 32px 24px;}
@@ -54,15 +59,16 @@ def apply_theme() -> None:
 def render_navbar() -> None:
     """Render the fixed top navigation bar."""
 
-    links = "".join(
-        f'<a href="{url}" target="_blank" rel="noopener noreferrer">{label}</a>'
+    links_html = "".join(
+        f"<a class='{ 'book-demo' if label == 'Book a Demo' else '' }' "
+        f'href="{url}" target="_blank" rel="noopener noreferrer">{label}</a>'
         for label, url in NAV_LINKS
     )
     st.markdown(
         f"""
         <nav class="vs-navbar">
             <img src="https://www.verdesat.com/favicon.svg" alt="VerdeSat logo" />
-            {links}
+            <div class="vs-nav-links">{links_html}</div>
         </nav>
         """,
         unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- right-align navbar links and lighten "Book a Demo" styling
- reorder sidebar controls and bump version label
- reposition hero and canvas sections for improved flow

## Testing
- `black .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689267e651d4832182d779b6c0ff3343