### PR TITLE
fix: average dashboard metrics across AOIs

### DIFF
--- a/tests/webapp/test_kpi_cards.py
+++ b/tests/webapp/test_kpi_cards.py
@@ -1,0 +1,30 @@
+import pandas as pd
+import pytest
+
+from verdesat.webapp.components.kpi_cards import aggregate_metrics
+
+
+def test_aggregate_metrics_computes_means():
+    df = pd.DataFrame(
+        {
+            "intactness": [0.2, 0.4],
+            "shannon": [0.3, 0.5],
+            "fragmentation": [0.1, 0.3],
+            "ndvi_mean": [0.1, 0.2],
+            "ndvi_std": [0.01, 0.03],
+            "ndvi_slope": [0.05, -0.05],
+            "ndvi_delta": [0.02, 0.04],
+            "ndvi_p_value": [0.1, 0.2],
+            "ndvi_peak": ["Jan", "Jan"],
+            "ndvi_pct_fill": [80.0, 90.0],
+            "msavi_mean": [0.6, 0.8],
+            "msavi_std": [0.02, 0.04],
+            "bscore": [50.0, 70.0],
+        }
+    )
+
+    metrics = aggregate_metrics(df)
+
+    assert metrics.intactness == pytest.approx(0.3)
+    assert metrics.bscore == pytest.approx(60.0)
+    assert metrics.ndvi_peak == "Jan"

--- a/verdesat/webapp/app.py
+++ b/verdesat/webapp/app.py
@@ -4,10 +4,9 @@ __doc__ = "Streamlit dashboard for visualising VerdeSat project metrics."
 
 import json
 import logging
-from dataclasses import fields
 from datetime import date
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 import geopandas as gpd
 import pandas as pd
@@ -23,7 +22,12 @@ from verdesat.webapp.components.charts import (
     msavi_bar_chart_all,
     ndvi_component_chart,
 )
-from verdesat.webapp.components.kpi_cards import Metrics, bscore_gauge, display_metrics
+from verdesat.webapp.components.kpi_cards import (
+    Metrics,
+    aggregate_metrics,
+    bscore_gauge,
+    display_metrics,
+)
 from verdesat.webapp.components.map_widget import display_map
 from verdesat.webapp.components.layout import (
     apply_theme,
@@ -284,10 +288,7 @@ elif st.session_state.get("run_requested"):
         [{**a.static_props, "geometry": a.geometry} for a in project.aois],
         crs="EPSG:4326",
     )
-    first_row = metrics_df.iloc[0].to_dict()
-    metric_fields = {f.name for f in fields(Metrics)}
-    metric_data = {k: first_row[k] for k in metric_fields if k in first_row}
-    metrics = Metrics(**cast(dict[str, Any], metric_data))
+    metrics = aggregate_metrics(metrics_df)
     st.session_state["results"] = {
         "gdf": gdf,
         "metrics_df": metrics_df,

--- a/verdesat/webapp/components/kpi_cards.py
+++ b/verdesat/webapp/components/kpi_cards.py
@@ -81,7 +81,7 @@ def bscore_gauge(score: float, *, title: str | None = None) -> None:
                 "bar": {"color": "#159466"},
                 "bgcolor": "white",
             },
-            title={"text": title or "B-Score"},
+            title={"text": title or "Project B-Score"},
         )
     )
     st.plotly_chart(fig, use_container_width=True)

--- a/verdesat/webapp/components/kpi_cards.py
+++ b/verdesat/webapp/components/kpi_cards.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 """Reusable KPI card components for the Streamlit dashboard."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
+from typing import Any, cast
 
+import pandas as pd
 import plotly.graph_objects as go
 import streamlit as st
 
@@ -25,6 +27,26 @@ class Metrics:
     msavi_mean: float
     msavi_std: float
     bscore: float
+
+
+def aggregate_metrics(df: pd.DataFrame) -> Metrics:
+    """Return mean values for ``df`` as a :class:`Metrics` instance.
+
+    The mean is computed column-wise for all numeric metric fields. For the
+    ``ndvi_peak`` column, the modal (most frequent) value is used.
+    """
+
+    metric_fields = {f.name for f in fields(Metrics)}
+    numeric_fields = [
+        field for field in metric_fields if field != "ndvi_peak" and field in df.columns
+    ]
+    data: dict[str, float | str] = df[numeric_fields].mean(numeric_only=True).to_dict()
+    data["ndvi_peak"] = (
+        str(df["ndvi_peak"].mode().iat[0])
+        if "ndvi_peak" in df.columns and not df["ndvi_peak"].empty
+        else ""
+    )
+    return Metrics(**cast(dict[str, Any], data))
 
 
 def display_metrics(metrics: Metrics) -> None:


### PR DESCRIPTION
## Summary
- average metrics across all AOIs for KPI cards and B-score gauge
- add metrics aggregation helper and unit test

## Testing
- `black .`
- `mypy .`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6894f3421cc88321ae6b2fa0550aa9eb