### PR TITLE
fix: clean up temporary Earth Engine credentials

### DIFF
--- a/verdesat/ingestion/eemanager.py
+++ b/verdesat/ingestion/eemanager.py
@@ -86,7 +86,13 @@ class EarthEngineManager:
                     sa_inline_credentials: Any = ee.ServiceAccountCredentials(
                         creds_data.get("client_email"), temp_path  # type: ignore[arg-type]
                     )
-                    ee.Initialize(sa_inline_credentials, project=project)
+                    try:
+                        ee.Initialize(sa_inline_credentials, project=project)
+                    finally:
+                        os.remove(temp_path)
+                        self.logger.debug(
+                            "Deleted temporary service-account JSON file %s", temp_path
+                        )
                     return
                 else:
                     ee.Initialize(project=project)


### PR DESCRIPTION
## Summary
- ensure temporary service-account JSON is removed after Earth Engine initialization

## Testing
- `black verdesat/ingestion/eemanager.py`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ac8f1d6483218ba03c8da114f3d8