### PR TITLE
fix: sanitize path identifiers

### DIFF
--- a/tests/webapp/test_project_state.py
+++ b/tests/webapp/test_project_state.py
@@ -28,3 +28,15 @@ def test_persist_project(tmp_path):
     saved = json.loads(Path(uri).read_text())
     assert saved["metadata"]["name"] == "TestProj"
     assert len(saved["features"]) == 1
+
+
+def test_persist_project_sanitizes_name(tmp_path):
+    aoi = AOI(Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]), {"id": 1})
+    project = Project("../evil", "Cust", [aoi], ConfigManager())
+    storage = TempStorage(str(tmp_path))
+    uri = persist_project(project, storage)
+    saved_path = Path(uri)
+    assert saved_path.parent == tmp_path / "projects"
+    assert saved_path.name == "evil.geojson"
+    saved = json.loads(saved_path.read_text())
+    assert saved["metadata"]["name"] == "../evil"

--- a/verdesat/core/utils.py
+++ b/verdesat/core/utils.py
@@ -1,0 +1,18 @@
+"""Utility helpers for core modules."""
+
+from __future__ import annotations
+
+import os
+import re
+
+
+def sanitize_identifier(identifier: str) -> str:
+    """Return a filesystem-safe version of ``identifier``.
+
+    The input string is reduced to its basename and any character outside the
+    ``[A-Za-z0-9_]`` set is replaced with an underscore.  If the sanitized value
+    would be empty, ``"unknown"`` is returned.
+    """
+    base = os.path.basename(identifier)
+    sanitized = re.sub(r"[^A-Za-z0-9_]", "_", base)
+    return sanitized or "unknown"

--- a/verdesat/services/landcover.py
+++ b/verdesat/services/landcover.py
@@ -14,6 +14,7 @@ from verdesat.services.raster_utils import convert_to_cog
 from verdesat.geo.aoi import AOI
 from verdesat.ingestion.eemanager import EarthEngineManager, ee_manager
 from verdesat.core.storage import LocalFS, StorageAdapter
+from verdesat.core.utils import sanitize_identifier
 from .base import BaseService
 
 
@@ -127,9 +128,10 @@ class LandcoverService(BaseService):
             else:
                 raise
 
-        pid = aoi.static_props.get("id") or aoi.static_props.get(
+        raw_pid = aoi.static_props.get("id") or aoi.static_props.get(
             "system:index", "unknown"
         )
+        pid = sanitize_identifier(str(raw_pid))
         filename = f"LANDCOVER_{pid}_{year}.tif"
         output = self.storage.join(out_dir, filename)
 

--- a/verdesat/visualization/chips.py
+++ b/verdesat/visualization/chips.py
@@ -1,6 +1,5 @@
 """Module implementing ChipExporter and ChipService for exporting image chips via GEE."""
 
-import os
 from typing import Any, Dict, List, Optional, Union
 
 import ee
@@ -17,6 +16,7 @@ from verdesat.ingestion.sensorspec import SensorSpec
 from verdesat.visualization._chips_config import ChipsConfig
 from verdesat.core.logger import Logger
 from verdesat.core.storage import LocalFS, StorageAdapter
+from verdesat.core.utils import sanitize_identifier
 
 
 class ChipExporter:
@@ -115,9 +115,10 @@ class ChipExporter:
         str | None
             Destination URI if successful, otherwise ``None``.
         """
-        pid = aoi.static_props.get("id") or aoi.static_props.get(
+        raw_pid = aoi.static_props.get("id") or aoi.static_props.get(
             "system:index", "unknown"
         )
+        pid = sanitize_identifier(str(raw_pid))
 
         try:
             geom = aoi.buffered_ee_geometry(buffer_m)

--- a/verdesat/webapp/services/project_state.py
+++ b/verdesat/webapp/services/project_state.py
@@ -16,6 +16,7 @@ from shapely.geometry import mapping
 
 from verdesat.project.project import Project
 from verdesat.core.storage import StorageAdapter
+from verdesat.core.utils import sanitize_identifier
 
 
 def persist_project(project: Project, storage: StorageAdapter) -> str:
@@ -40,6 +41,7 @@ def persist_project(project: Project, storage: StorageAdapter) -> str:
         "features": features,
         "metadata": {"name": project.name, "customer": project.customer},
     }
-    uri = storage.join("projects", f"{project.name}.geojson")
+    safe_name = sanitize_identifier(project.name)
+    uri = storage.join("projects", f"{safe_name}.geojson")
     storage.write_bytes(uri, json.dumps(data).encode("utf-8"))
     return uri


### PR DESCRIPTION
## Summary
- add helper to sanitize user-provided identifiers for filesystem paths
- sanitize AOI and project identifiers in chip export, landcover download, and project persistence
- test that path traversal attempts are contained to intended directories

## Testing
- `black .`
- `mypy .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6895bc35e3c08321af299b3ffc1789e9