### PR TITLE
fix: sanitize project metadata and paths

### DIFF
--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -84,3 +84,12 @@ def test_from_geojson_reads_metadata_and_area() -> None:
     assert project.customer == "MetaCust"
     assert "area_m2" in project.aois[0].static_props
     assert project.aois[0].static_props["area_m2"] > 0
+
+
+def test_from_geojson_sanitizes_metadata() -> None:
+    config = ConfigManager()
+    gj = _geojson()
+    gj["metadata"] = {"name": "../bad*proj", "customer": "Cust<>\n"}
+    project = Project.from_geojson(gj, config)
+    assert project.name == "badproj"
+    assert project.customer == "Cust"

--- a/tests/webapp/test_project_state.py
+++ b/tests/webapp/test_project_state.py
@@ -40,3 +40,15 @@ def test_persist_project_sanitizes_name(tmp_path):
     assert saved_path.name == "evil.geojson"
     saved = json.loads(saved_path.read_text())
     assert saved["metadata"]["name"] == "../evil"
+
+
+def test_persist_project_handles_special_chars(tmp_path):
+    aoi = AOI(Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]), {"id": 1})
+    project = Project("my!@#../proj", "Cust", [aoi], ConfigManager())
+    storage = TempStorage(str(tmp_path))
+    uri = persist_project(project, storage)
+    saved_path = Path(uri)
+    assert saved_path.parent == tmp_path / "projects"
+    assert saved_path.name == "myproj.geojson"
+    saved = json.loads(saved_path.read_text())
+    assert saved["metadata"]["name"] == "my!@#../proj"

--- a/verdesat/project/project.py
+++ b/verdesat/project/project.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import logging
+import re
 from typing import Any, Dict, List, Literal
 
 import geopandas as gpd
@@ -55,8 +56,10 @@ class Project:
 
         log = logger or Logger.get_logger(__name__)
         meta = geojson.get("metadata", {})
-        proj_name = name or meta.get("name", "Uploaded Project")
-        proj_customer = customer or meta.get("customer", "Guest")
+        proj_name_raw = name or meta.get("name", "Uploaded Project")
+        proj_customer_raw = customer or meta.get("customer", "Guest")
+        proj_name = re.sub(r"[^A-Za-z0-9_\-]", "", proj_name_raw)
+        proj_customer = re.sub(r"[^A-Za-z0-9_\-]", "", proj_customer_raw)
 
         id_col = config.get("id_col", "id")
         features = geojson.get("features", [])

--- a/verdesat/webapp/services/project_state.py
+++ b/verdesat/webapp/services/project_state.py
@@ -10,13 +10,13 @@ persist project state for authenticated users.
 from __future__ import annotations
 
 import json
+import re
 from typing import Any
 
 from shapely.geometry import mapping
 
 from verdesat.project.project import Project
 from verdesat.core.storage import StorageAdapter
-from verdesat.core.utils import sanitize_identifier
 
 
 def persist_project(project: Project, storage: StorageAdapter) -> str:
@@ -41,7 +41,7 @@ def persist_project(project: Project, storage: StorageAdapter) -> str:
         "features": features,
         "metadata": {"name": project.name, "customer": project.customer},
     }
-    safe_name = sanitize_identifier(project.name)
+    safe_name = re.sub(r"[^A-Za-z0-9_\-]", "", project.name)
     uri = storage.join("projects", f"{safe_name}.geojson")
     storage.write_bytes(uri, json.dumps(data).encode("utf-8"))
     return uri


### PR DESCRIPTION
## Summary
- sanitize project name and customer fields when loading from GeoJSON
- ensure persisted project files use sanitized identifiers
- add tests guarding against path traversal and special-character names

## Testing
- `black tests/project/test_project.py tests/webapp/test_project_state.py verdesat/project/project.py verdesat/webapp/services/project_state.py`
- `mypy .`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895c9082c5883218b19bc328ef8a2e3