### PR TITLE
fix: validate FeatureCollection input

### DIFF
--- a/tests/project/test_project.py
+++ b/tests/project/test_project.py
@@ -1,4 +1,7 @@
 from __future__ import annotations
+
+import pytest
+
 from verdesat.core.config import ConfigManager
 from verdesat.project.project import Project
 
@@ -93,3 +96,11 @@ def test_from_geojson_sanitizes_metadata() -> None:
     project = Project.from_geojson(gj, config)
     assert project.name == "badproj"
     assert project.customer == "Cust"
+
+
+def test_from_geojson_validates_input() -> None:
+    config = ConfigManager()
+    with pytest.raises(ValueError):
+        Project.from_geojson({"type": "Feature"}, config)
+    with pytest.raises(ValueError):
+        Project.from_geojson({"type": "FeatureCollection"}, config)

--- a/verdesat/project/project.py
+++ b/verdesat/project/project.py
@@ -55,6 +55,12 @@ class Project:
         """
 
         log = logger or Logger.get_logger(__name__)
+        if geojson.get("type") != "FeatureCollection" or not isinstance(
+            geojson.get("features"), list
+        ):
+            raise ValueError(
+                "GeoJSON must be a FeatureCollection with a 'features' array"
+            )
         meta = geojson.get("metadata", {})
         proj_name_raw = name or meta.get("name", "Uploaded Project")
         proj_customer_raw = customer or meta.get("customer", "Guest")

--- a/verdesat/webapp/app.py
+++ b/verdesat/webapp/app.py
@@ -221,19 +221,23 @@ if uploaded_file is not None:
             except json.JSONDecodeError:
                 st.sidebar.error("Invalid GeoJSON file")
             else:
-                meta = geojson.get("metadata", {})
-                st.session_state["project"] = Project.from_geojson(
-                    geojson,
-                    CONFIG,
-                    name=meta.get("name"),
-                    customer=meta.get("customer"),
-                    storage=storage,
-                )
-                st.session_state["uploaded_filename"] = uploaded_file.name
-                st.session_state["run_requested"] = False
-                st.session_state.pop("main_map", None)
-                st.session_state.pop("main_map_center", None)
-                st.session_state.pop("main_map_zoom", None)
+                try:
+                    meta = geojson.get("metadata", {})
+                    st.session_state["project"] = Project.from_geojson(
+                        geojson,
+                        CONFIG,
+                        name=meta.get("name"),
+                        customer=meta.get("customer"),
+                        storage=storage,
+                    )
+                except ValueError as exc:
+                    st.sidebar.error(str(exc))
+                else:
+                    st.session_state["uploaded_filename"] = uploaded_file.name
+                    st.session_state["run_requested"] = False
+                    st.session_state.pop("main_map", None)
+                    st.session_state.pop("main_map_center", None)
+                    st.session_state.pop("main_map_zoom", None)
 
 if st.sidebar.button(
     "Run analysis",


### PR DESCRIPTION
## Summary
- ensure `Project.from_geojson` only accepts FeatureCollection inputs
- surface validation errors in web UI when uploading invalid GeoJSON
- test that invalid GeoJSON is rejected

## Testing
- `black .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895ce43cb64832192a5dbdfe7914999