### PR TITLE
Add AI report service skeleton and schemas

### DIFF
--- a/tests/services/test_ai_report.py
+++ b/tests/services/test_ai_report.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import logging
+import pytest
+
+from verdesat.core.config import ConfigManager
+from verdesat.core.storage import LocalFS
+from verdesat.schemas.ai_report import AiReportRequest
+from verdesat.services.ai_report import AiReportService, LlmClient
+
+
+class DummyLlm:
+    def generate(self, prompt: str, **kwargs):  # pragma: no cover - placeholder
+        return {}
+
+
+def _service() -> AiReportService:
+    return AiReportService(
+        llm=DummyLlm(),
+        storage=LocalFS(),
+        logger=logging.getLogger("test"),
+        config=ConfigManager(),
+    )
+
+
+def test_init_sets_dependencies():
+    service = _service()
+    assert service.llm is not None
+    assert service.storage is not None
+    assert service.logger is not None
+    assert service.config is not None
+
+
+def test_generate_summary_not_implemented():
+    service = _service()
+    req = AiReportRequest(
+        aoi_id="a1",
+        project_id="p1",
+        metrics_path="metrics.csv",
+        timeseries_path="ts.csv",
+    )
+    with pytest.raises(NotImplementedError):
+        service.generate_summary(req)

--- a/verdesat/schemas/ai_report.py
+++ b/verdesat/schemas/ai_report.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+"""Data models for AI report generation.
+
+The original design proposed using Pydantic models. To stay aligned with the
+rest of the codebase, these schemas use :mod:`dataclasses` instead.
+"""
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Dict
+
+
+@dataclass
+class MetricsSummary:
+    """Aggregated AOI metrics passed to the language model."""
+
+    aoi_id: str
+    project_id: str
+    method_version: str
+    window_start: date
+    window_end: date
+    intactness_pct: float | None = None
+    frag_norm: float | None = None
+    shannon: float | None = None
+    bscore: float | None = None
+    ndvi_mean: float | None = None
+    ndvi_slope_per_year: float | None = None
+    ndvi_delta_yoy: float | None = None
+    valid_obs_pct: float | None = None
+    pixel_count_total: int | None = None
+    pixel_count_valid: int | None = None
+    msa_mean_2015: float | None = None
+    landcover_mode: int | None = None
+    landcover_entropy: float | None = None
+    wdpa_inside: bool | None = None
+    nearest_pa_name: str | None = None
+    nearest_pa_distance_km: float | None = None
+    nearest_kba_name: str | None = None
+    nearest_kba_distance_km: float | None = None
+    area_ha: float | None = None
+    centroid_lat: float | None = None
+    centroid_lon: float | None = None
+    ecoregion: str | None = None
+    elevation_mean_m: float | None = None
+    slope_mean_deg: float | None = None
+
+
+@dataclass
+class TimeseriesRow:
+    """Single observation from the VI time series."""
+
+    date: date
+    metric: str
+    value: float
+    aoi_id: str
+
+
+@dataclass
+class AiReportRequest:
+    """Parameters for :class:`AiReportService.generate_summary`."""
+
+    aoi_id: str
+    project_id: str
+    metrics_path: str
+    timeseries_path: str
+    lineage_path: str | None = None
+    model: str | None = None
+    prompt_version: str | None = None
+    force: bool = False
+
+
+@dataclass
+class AiReportResult:
+    """Result returned by the AI report service."""
+
+    aoi_id: str
+    project_id: str
+    model: str
+    prompt_version: str
+    summary: Dict[str, Any]
+    narrative: str
+    uri: str | None = None
+
+
+__all__ = [
+    "MetricsSummary",
+    "TimeseriesRow",
+    "AiReportRequest",
+    "AiReportResult",
+]

--- a/verdesat/services/ai_report.py
+++ b/verdesat/services/ai_report.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Service skeleton for LLM-based report summaries."""
+
+import logging
+from typing import Any, Dict, Protocol
+
+from verdesat.core.config import ConfigManager
+from verdesat.core.storage import StorageAdapter
+from verdesat.schemas.ai_report import AiReportRequest, AiReportResult
+
+
+class LlmClient(Protocol):
+    """Minimal interface for language model clients."""
+
+    def generate(self, prompt: str, **kwargs: Any) -> Dict[str, Any]:
+        """Return structured output for *prompt*."""
+
+
+class AiReportService:
+    """Create AI-generated summaries for project AOIs."""
+
+    def __init__(
+        self,
+        *,
+        llm: LlmClient,
+        storage: StorageAdapter,
+        logger: logging.Logger,
+        config: ConfigManager,
+    ) -> None:
+        self.llm = llm
+        self.storage = storage
+        self.logger = logger
+        self.config = config
+
+    def generate_summary(self, request: AiReportRequest) -> AiReportResult:
+        """Generate or retrieve a cached AI report summary."""
+        raise NotImplementedError


### PR DESCRIPTION
## Summary
- add `AiReportService` skeleton with constructor DI for language model client, storage, logger, and config
- define dataclass schemas for metrics summaries, time series rows, service requests, and results
- cover service initialization and placeholder method with a unit test

## Testing
- `black verdesat/services/ai_report.py verdesat/schemas/ai_report.py tests/services/test_ai_report.py`
- `flake8 verdesat/services/ai_report.py verdesat/schemas/ai_report.py tests/services/test_ai_report.py`
- `mypy verdesat/services/ai_report.py verdesat/schemas/ai_report.py`
- `PYTHONPATH=$PWD pytest tests/services/test_ai_report.py -q`
- `PYTHONPATH=$PWD pytest -q` *(fails: ModuleNotFoundError: No module named 'imageio'; additional missing deps include jinja2, rasterio, plotly, Pillow, boto3)*

------
https://chatgpt.com/codex/tasks/task_e_689a186d14bc83218f4da1089b78ca87