### PR TITLE
feat: add OpenAI LLM adapter and prompt store

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1,8 +1,24 @@
 # MODULES — Auto-generated overview
 
-_Generated: 2025-08-08T11:41:26Z_
+_Generated: 2025-08-11T17:01:49Z_
 
 ## `verdesat`
+
+## `verdesat.adapters`
+> Adapters for external services (APIs, storage, etc.).
+
+## `verdesat.adapters.llm_openai`
+> OpenAI client adapter implementing :class:`~verdesat.services.ai_report.LlmClient`.
+**Classes**
+- `OpenAiLlmClient` — LLM client using the OpenAI Responses API.
+
+## `verdesat.adapters.prompt_store`
+> Central store for versioned prompts used by :mod:`ai_report` services.
+**Classes**
+- `PromptBundle` — Container for the different prompt roles.
+
+**Functions**
+- `get_prompts` — Return prompts for *version*.
 
 ## `verdesat.analytics`
 > Analytics helpers and result data types.
@@ -183,8 +199,22 @@ _Generated: 2025-08-08T11:41:26Z_
 **Classes**
 - `Project` — Lightweight project model holding AOIs and related artefacts.
 
+## `verdesat.schemas`
+
+## `verdesat.schemas.ai_report`
+**Classes**
+- `MetricsSummary` — Aggregated AOI metrics passed to the language model.
+- `TimeseriesRow` — Single observation from the VI time series.
+- `AiReportRequest` — Parameters for :class:`AiReportService.generate_summary`.
+- `AiReportResult` — Result returned by the AI report service.
+
 ## `verdesat.services`
 > Lightweight service-layer helpers used by the CLI and tests.
+
+## `verdesat.services.ai_report`
+**Classes**
+- `LlmClient` — Minimal interface for language model clients.
+- `AiReportService` — Create AI-generated summaries for project AOIs.
 
 ## `verdesat.services.base`
 **Classes**

--- a/tests/adapters/test_llm_openai.py
+++ b/tests/adapters/test_llm_openai.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+from pydantic import BaseModel
+
+from verdesat.adapters.llm_openai import OpenAiLlmClient
+
+
+class _Content:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _Output:
+    def __init__(self, text: str) -> None:
+        self.content = [_Content(text)]
+
+
+class _Response:
+    def __init__(self, text: str) -> None:
+        self.output = [_Output(text)]
+
+
+class _Responses:
+    def __init__(self, texts: list[str], calls: list[Dict[str, Any]]) -> None:
+        self._texts = texts
+        self._calls = calls
+
+    def create(self, **kwargs: Any) -> _Response:
+        self._calls.append(kwargs)
+        text = self._texts.pop(0)
+        return _Response(text)
+
+
+class FakeOpenAI:
+    def __init__(self, texts: list[str]) -> None:
+        self.calls: list[Dict[str, Any]] = []
+        self.responses = _Responses(texts, self.calls)
+
+
+class OutputModel(BaseModel):
+    answer: str
+
+
+def test_generate_passes_deterministic_params() -> None:
+    client = OpenAiLlmClient(client=FakeOpenAI(['{"answer": "ok"}']), seed=99)
+    result = client.generate("hi", response_model=OutputModel, model="gpt-4o-mini")
+    assert result == {"answer": "ok"}
+    params = client._client.calls[0]  # type: ignore[attr-defined]
+    assert params["temperature"] == 0
+    assert params["top_p"] == 1
+    assert params["seed"] == 99
+    assert params["model"] == "gpt-4o-mini"
+    schema = OutputModel.model_json_schema()
+    assert params["response_format"]["json_schema"]["schema"] == schema
+
+
+def test_generate_retries_on_validation_error() -> None:
+    texts = ["not json", '{"answer": "ok"}']
+    fake = FakeOpenAI(texts)
+    client = OpenAiLlmClient(client=fake, max_retries=1)
+    result = client.generate("hi", response_model=OutputModel, model="gpt-4o-mini")
+    assert result == {"answer": "ok"}
+    assert len(fake.calls) == 2
+
+
+def test_generate_raises_after_retry() -> None:
+    texts = ["not json", "still bad"]
+    fake = FakeOpenAI(texts)
+    client = OpenAiLlmClient(client=fake, max_retries=1)
+    with pytest.raises(Exception):
+        client.generate("hi", response_model=OutputModel, model="gpt-4o-mini")

--- a/tests/adapters/test_prompt_store.py
+++ b/tests/adapters/test_prompt_store.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from verdesat.adapters.prompt_store import PROMPT_VERSION, get_prompts
+
+
+def test_get_prompts_returns_bundle():
+    bundle = get_prompts()
+    assert bundle.system
+    assert bundle.developer
+    assert bundle.user
+
+
+def test_get_prompts_unknown_version():
+    with pytest.raises(ValueError):
+        get_prompts("v999")
+
+
+def test_prompt_version_constant():
+    assert isinstance(PROMPT_VERSION, str)

--- a/verdesat/adapters/__init__.py
+++ b/verdesat/adapters/__init__.py
@@ -1,0 +1,6 @@
+"""Adapters for external services (APIs, storage, etc.)."""
+
+from .llm_openai import OpenAiLlmClient
+from .prompt_store import PROMPT_VERSION, get_prompts
+
+__all__ = ["OpenAiLlmClient", "get_prompts", "PROMPT_VERSION"]

--- a/verdesat/adapters/llm_openai.py
+++ b/verdesat/adapters/llm_openai.py
@@ -1,0 +1,85 @@
+"""OpenAI client adapter implementing :class:`~verdesat.services.ai_report.LlmClient`.
+
+This adapter uses the OpenAI Responses API with Structured Outputs. Responses
+are validated against a supplied Pydantic model to guarantee the schema. The
+call is deterministic (``temperature=0``, ``top_p=1`` and seeded) and will retry
+once when schema validation fails.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Type
+
+from openai import OpenAI
+from openai._exceptions import OpenAIError
+from pydantic import BaseModel, ValidationError
+
+
+class OpenAiLlmClient:
+    """LLM client using the OpenAI Responses API."""
+
+    def __init__(
+        self,
+        *,
+        client: OpenAI | None = None,
+        seed: int = 42,
+        max_retries: int = 1,
+    ) -> None:
+        self._client = client or OpenAI()
+        self._seed = seed
+        self._max_retries = max_retries
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        response_model: Type[BaseModel],
+        model: str,
+    ) -> Dict[str, Any]:
+        """Generate structured output for *prompt* using *response_model*.
+
+        Parameters
+        ----------
+        prompt:
+            User prompt content.
+        response_model:
+            Pydantic model describing the expected JSON schema.
+        model:
+            OpenAI model name.
+
+        Returns
+        -------
+        Dict[str, Any]
+            Parsed model output as a Python dictionary.
+        """
+
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                response = self._client.responses.create(
+                    model=model,
+                    input=prompt,
+                    temperature=0,
+                    top_p=1,
+                    seed=self._seed,
+                    response_format={
+                        "type": "json_schema",
+                        "json_schema": {
+                            "name": response_model.__name__,
+                            "schema": response_model.model_json_schema(),
+                            "strict": True,
+                        },
+                    },
+                )
+                content = response.output[0].content[0].text
+            except OpenAIError as exc:  # pragma: no cover - network errors
+                raise RuntimeError("OpenAI request failed") from exc
+
+            try:
+                parsed = response_model.model_validate_json(content)
+                return parsed.model_dump()
+            except ValidationError:
+                if attempt > self._max_retries:
+                    raise
+                continue

--- a/verdesat/adapters/prompt_store.py
+++ b/verdesat/adapters/prompt_store.py
@@ -1,0 +1,53 @@
+"""Central store for versioned prompts used by :mod:`ai_report` services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+PROMPT_VERSION = "v1"
+
+
+@dataclass(frozen=True)
+class PromptBundle:
+    """Container for the different prompt roles."""
+
+    system: str
+    developer: str
+    user: str
+
+
+_PROMPTS: dict[str, PromptBundle] = {
+    "v1": PromptBundle(
+        system=(
+            "You are an environmental analyst producing screening-grade reports. "
+            "Stay objective and cite numeric keys (e.g., ndvi_mean=0.57)."
+        ),
+        developer=(
+            "Output must comply with ai_report.v1 schema. Use metric units, no legal"
+            " or species claims. Round values to two decimals."
+        ),
+        user=(
+            "AOI {aoi_id} ({project_id})\n"
+            "WINDOW: {window_start} → {window_end}\n"
+            "METRICS ROW:\n{metrics_row}\n"
+            "TIME SERIES (ndvi; YYYY-MM, value):\n{timeseries}\n"
+            "CONTEXT: {context}\n"
+            "Produce JSON conforming to schema ai_report.v1 only."
+        ),
+    )
+}
+
+
+def get_prompts(version: str = PROMPT_VERSION) -> PromptBundle:
+    """Return prompts for *version*.
+
+    Parameters
+    ----------
+    version:
+        Prompt version identifier. Defaults to :data:`PROMPT_VERSION`.
+    """
+
+    try:
+        return _PROMPTS[version]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unknown prompt version: {version}") from exc


### PR DESCRIPTION
## Summary
- add OpenAI Responses API client implementing LlmClient interface with structured outputs and retry
- provide versioned prompt store with `PROMPT_VERSION` constant for caching
- test LLM client determinism and prompt retrieval

## Testing
- `ruff check verdesat/adapters tests/adapters`
- `black verdesat/adapters tests/adapters --check`
- `mypy verdesat/adapters tests/adapters`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a1cf886f48321ad61e6121b799dc4