### PR TITLE
feat(ai-report): add input hashing and local cache

### DIFF
--- a/tests/services/test_ai_report.py
+++ b/tests/services/test_ai_report.py
@@ -1,43 +1,103 @@
 from __future__ import annotations
 
+import hashlib
 import logging
-import pytest
+from pathlib import Path
 
+from verdesat.adapters.prompt_store import get_prompts
 from verdesat.core.config import ConfigManager
 from verdesat.core.storage import LocalFS
 from verdesat.schemas.ai_report import AiReportRequest
-from verdesat.services.ai_report import AiReportService, LlmClient
+from verdesat.services.ai_report import AiReportService
 
 
 class DummyLlm:
-    def generate(self, prompt: str, **kwargs):  # pragma: no cover - placeholder
-        return {}
+    """Simple LLM client that records calls."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def generate(self, prompt: str, **kwargs):
+        self.calls += 1
+        return {"summary": {"ok": True}, "narrative": "narr"}
 
 
-def _service() -> AiReportService:
+def _service(llm: DummyLlm, storage: LocalFS) -> AiReportService:
     return AiReportService(
-        llm=DummyLlm(),
-        storage=LocalFS(),
+        llm=llm,
+        storage=storage,
         logger=logging.getLogger("test"),
         config=ConfigManager(),
     )
 
 
-def test_init_sets_dependencies():
-    service = _service()
-    assert service.llm is not None
-    assert service.storage is not None
-    assert service.logger is not None
-    assert service.config is not None
+def _write(storage: LocalFS, path: Path, content: str) -> str:
+    storage.write_bytes(str(path), content.encode("utf-8"))
+    return str(path)
 
 
-def test_generate_summary_not_implemented():
-    service = _service()
+def test_compute_hash(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    storage = LocalFS()
+    llm = DummyLlm()
+    svc = _service(llm, storage)
+
+    metrics = Path("metrics.csv")
+    timeseries = Path("ts.csv")
+    lineage = Path("lineage.json")
+    _write(storage, metrics, "m")
+    _write(storage, timeseries, "t")
+    _write(storage, lineage, "{}")
+
     req = AiReportRequest(
         aoi_id="a1",
         project_id="p1",
-        metrics_path="metrics.csv",
-        timeseries_path="ts.csv",
+        metrics_path=str(metrics),
+        timeseries_path=str(timeseries),
+        lineage_path=str(lineage),
     )
-    with pytest.raises(NotImplementedError):
-        service.generate_summary(req)
+
+    digest = svc._compute_hash(req, model="model-x", prompt_version="v1")
+    prompts = get_prompts("v1")
+    expected = hashlib.sha256(
+        b"".join(
+            [
+                metrics.read_bytes(),
+                timeseries.read_bytes(),
+                lineage.read_bytes(),
+                prompts.system.encode("utf-8"),
+                prompts.developer.encode("utf-8"),
+                prompts.user.encode("utf-8"),
+                b"model-x",
+            ]
+        )
+    ).hexdigest()
+    assert digest == expected
+
+
+def test_generate_summary_caches(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    storage = LocalFS()
+    llm = DummyLlm()
+    svc = _service(llm, storage)
+
+    metrics = Path("metrics.csv")
+    timeseries = Path("ts.csv")
+    _write(storage, metrics, "m")
+    _write(storage, timeseries, "t")
+
+    req = AiReportRequest(
+        aoi_id="a1",
+        project_id="p1",
+        metrics_path=str(metrics),
+        timeseries_path=str(timeseries),
+    )
+
+    res1 = svc.generate_summary(req)
+    assert llm.calls == 1
+    assert res1.uri and Path(res1.uri).exists()
+
+    res2 = svc.generate_summary(req)
+    assert llm.calls == 1  # cache hit
+    assert res2.summary == res1.summary
+    assert res2.narrative == res1.narrative

--- a/verdesat/services/ai_report.py
+++ b/verdesat/services/ai_report.py
@@ -1,13 +1,16 @@
+"""Service for LLM-based report summaries with caching."""
+
 from __future__ import annotations
 
-"""Service skeleton for LLM-based report summaries."""
-
+import hashlib
+import json
 import logging
 from typing import Any, Dict, Protocol
 
 from verdesat.core.config import ConfigManager
 from verdesat.core.storage import StorageAdapter
 from verdesat.schemas.ai_report import AiReportRequest, AiReportResult
+from verdesat.adapters.prompt_store import get_prompts
 
 
 class LlmClient(Protocol):
@@ -33,6 +36,75 @@ class AiReportService:
         self.logger = logger
         self.config = config
 
+    # ------------------------------------------------------------------
+    def _compute_hash(
+        self, request: AiReportRequest, model: str, prompt_version: str
+    ) -> str:
+        """Return SHA-256 hash for *request* inputs.
+
+        The hash incorporates the raw bytes of the metrics, time series, and
+        optional lineage files along with the prompt and model configuration.
+        """
+
+        prompts = get_prompts(prompt_version)
+        sha = hashlib.sha256()
+        for path in (
+            request.metrics_path,
+            request.timeseries_path,
+            request.lineage_path,
+        ):
+            if path:
+                sha.update(self.storage.read_bytes(path))
+        sha.update(prompts.system.encode("utf-8"))
+        sha.update(prompts.developer.encode("utf-8"))
+        sha.update(prompts.user.encode("utf-8"))
+        sha.update(model.encode("utf-8"))
+        return sha.hexdigest()
+
+    # ------------------------------------------------------------------
     def generate_summary(self, request: AiReportRequest) -> AiReportResult:
         """Generate or retrieve a cached AI report summary."""
-        raise NotImplementedError
+
+        model = request.model or self.config.get("ai_report_model", "gpt-4o-mini")
+        prompt_version = request.prompt_version or self.config.get(
+            "ai_report_prompt_version", "v1"
+        )
+        input_hash = self._compute_hash(request, model, prompt_version)
+        uri = self.storage.join("ai_reports", f"{input_hash}.json")
+
+        if not request.force:
+            try:
+                cached = self.storage.read_bytes(uri)
+                obj = json.loads(cached.decode("utf-8"))
+                self.logger.debug("loaded cached AI report %s", uri)
+                return AiReportResult(
+                    aoi_id=request.aoi_id,
+                    project_id=request.project_id,
+                    model=model,
+                    prompt_version=prompt_version,
+                    summary=obj.get("summary", {}),
+                    narrative=obj.get("narrative", ""),
+                    uri=uri,
+                )
+            except FileNotFoundError:
+                pass
+            except Exception:
+                self.logger.exception("failed to read cached report %s", uri)
+
+        payload = self.llm.generate("", model=model, prompt_version=prompt_version)
+        summary = payload.get("summary", {})
+        narrative = payload.get("narrative", "")
+        artifact = json.dumps(
+            {"summary": summary, "narrative": narrative}, sort_keys=True
+        ).encode("utf-8")
+        self.storage.write_bytes(uri, artifact)
+        self.logger.debug("stored AI report at %s", uri)
+        return AiReportResult(
+            aoi_id=request.aoi_id,
+            project_id=request.project_id,
+            model=model,
+            prompt_version=prompt_version,
+            summary=summary,
+            narrative=narrative,
+            uri=uri,
+        )


### PR DESCRIPTION
## Summary
- add read_bytes method to StorageAdapter implementations
- compute SHA-256 hash over metrics, timeseries, lineage, prompt, and model to cache AI summaries
- persist and retrieve cached summaries via StorageAdapter

## Testing
- `ruff check verdesat/core/storage.py verdesat/services/ai_report.py tests/services/test_ai_report.py`
- `black verdesat/core/storage.py verdesat/services/ai_report.py tests/services/test_ai_report.py`
- `mypy verdesat/services/ai_report.py verdesat/core/storage.py`
- `pytest tests/services/test_ai_report.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a231d8b5c8321aa2da24783cc77e3