### PR TITLE
test: cover ai report service

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ verdesat = "verdesat.core.cli:cli"
 max-line-length = 100
 extend-ignore = ["E203", "W503", "E501", "F401", "F841"]
 
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests as slow/integration",
+]
+
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/services/test_ai_report.py
+++ b/tests/services/test_ai_report.py
@@ -1,48 +1,82 @@
+"""Tests for :mod:`verdesat.services.ai_report`."""
+
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
-from pathlib import Path
+import os
+from typing import Any
 
 import pandas as pd
+import pytest
+from pydantic import ValidationError
 
+from verdesat.adapters.llm_openai import OpenAiLlmClient
 from verdesat.adapters.prompt_store import get_prompts
 from verdesat.core.config import ConfigManager
-from verdesat.core.storage import LocalFS
+from verdesat.core.storage import StorageAdapter, LocalFS
 from verdesat.schemas.ai_report import AiReportRequest
 from verdesat.services.ai_report import AiReportService
 
 
-class DummyLlm:
-    """Simple LLM client that records calls."""
+class FakeStorage(StorageAdapter):
+    """In-memory :class:`StorageAdapter` for tests."""
 
-    def __init__(self) -> None:
+    def __init__(self) -> None:  # pragma: no cover - trivial
+        self.files: dict[str, bytes] = {}
+        self.reads = 0
+        self.writes = 0
+
+    def join(self, *parts: str) -> str:  # pragma: no cover - trivial
+        return "/".join(p.strip("/") for p in parts)
+
+    def write_bytes(self, uri: str, data: bytes) -> str:
+        self.writes += 1
+        self.files[uri] = data
+        return uri
+
+    def read_bytes(self, uri: str) -> bytes:
+        self.reads += 1
+        try:
+            return self.files[uri]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise FileNotFoundError(uri) from exc
+
+    def open_raster(self, uri: str, **kwargs):  # pragma: no cover - not used
+        raise NotImplementedError
+
+
+class RecordingLlm:
+    """LLM stub that records the last prompt and kwargs."""
+
+    def __init__(self, payload: Any) -> None:
+        self.payload = payload
         self.calls = 0
+        self.last_prompt: str | None = None
+        self.last_kwargs: dict[str, Any] = {}
 
-    def generate(self, prompt: str, **kwargs):
+    def generate(self, prompt: str, **kwargs: Any) -> Any:  # pragma: no cover - simple
         self.calls += 1
-        return {
-            "executive_summary": "exec",
-            "kpi_sentences": {
-                "bscore": "bscore sent",
-                "intactness": "intact sent",
-                "fragmentation": "frag sent",
-                "ndvi_trend": "ndvi sent",
-            },
-            "esrs_e4": {
-                "extent_condition": "extent",
-                "pressures": "press",
-                "targets": "targets",
-                "actions": "actions",
-                "financial_effects": "effects",
-            },
-            "flags": [],
-            "numbers": {},
-            "meta": {},
-        }
+        self.last_prompt = prompt
+        self.last_kwargs = kwargs
+        return self.payload
 
 
-def _service(llm: DummyLlm, storage: LocalFS) -> AiReportService:
+class SchemaLlm(RecordingLlm):
+    """LLM stub that validates against provided Pydantic model."""
+
+    def generate(self, prompt: str, **kwargs: Any) -> Any:
+        self.calls += 1
+        self.last_prompt = prompt
+        self.last_kwargs = kwargs
+        model = kwargs["response_model"]
+        if isinstance(self.payload, str):
+            return model.model_validate_json(self.payload).model_dump()
+        return model.model_validate(self.payload).model_dump()
+
+
+def _service(llm: RecordingLlm, storage: StorageAdapter) -> AiReportService:
     return AiReportService(
         llm=llm,
         storage=storage,
@@ -51,7 +85,7 @@ def _service(llm: DummyLlm, storage: LocalFS) -> AiReportService:
     )
 
 
-def _write_metrics(storage: LocalFS, path: Path) -> str:
+def _write_metrics(storage: FakeStorage, path: str) -> str:
     df = pd.DataFrame(
         {
             "aoi_id": ["a1"],
@@ -72,11 +106,11 @@ def _write_metrics(storage: LocalFS, path: Path) -> str:
             "elevation_mean_m": [100.0],
         }
     )
-    storage.write_bytes(str(path), df.to_csv(index=False).encode("utf-8"))
-    return str(path)
+    storage.write_bytes(path, df.to_csv(index=False).encode("utf-8"))
+    return path
 
 
-def _write_timeseries(storage: LocalFS, path: Path) -> str:
+def _write_timeseries(storage: FakeStorage, path: str) -> str:
     df = pd.DataFrame(
         {
             "date": ["2024-01-01", "2024-02-01"],
@@ -85,29 +119,26 @@ def _write_timeseries(storage: LocalFS, path: Path) -> str:
             "aoi_id": ["a1", "a1"],
         }
     )
-    storage.write_bytes(str(path), df.to_csv(index=False).encode("utf-8"))
-    return str(path)
+    storage.write_bytes(path, df.to_csv(index=False).encode("utf-8"))
+    return path
 
 
-def test_compute_hash(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    storage = LocalFS()
-    llm = DummyLlm()
+def test_compute_hash():
+    storage = FakeStorage()
+    llm = RecordingLlm({})
     svc = _service(llm, storage)
 
-    metrics = Path("metrics.csv")
-    timeseries = Path("ts.csv")
-    lineage = Path("lineage.json")
-    _write_metrics(storage, metrics)
-    _write_timeseries(storage, timeseries)
-    storage.write_bytes(str(lineage), b"{}")
+    metrics = _write_metrics(storage, "metrics.csv")
+    timeseries = _write_timeseries(storage, "ts.csv")
+    lineage_path = "lineage.json"
+    storage.write_bytes(lineage_path, b"{}")
 
     req = AiReportRequest(
         aoi_id="a1",
         project_id="p1",
-        metrics_path=str(metrics),
-        timeseries_path=str(timeseries),
-        lineage_path=str(lineage),
+        metrics_path=metrics,
+        timeseries_path=timeseries,
+        lineage_path=lineage_path,
     )
 
     digest = svc._compute_hash(req, model="model-x", prompt_version="v1")
@@ -115,9 +146,9 @@ def test_compute_hash(tmp_path, monkeypatch):
     expected = hashlib.sha256(
         b"".join(
             [
-                metrics.read_bytes(),
-                timeseries.read_bytes(),
-                lineage.read_bytes(),
+                storage.files[metrics],
+                storage.files[timeseries],
+                storage.files[lineage_path],
                 prompts.system.encode("utf-8"),
                 prompts.developer.encode("utf-8"),
                 prompts.user.encode("utf-8"),
@@ -128,31 +159,152 @@ def test_compute_hash(tmp_path, monkeypatch):
     assert digest == expected
 
 
-def test_generate_summary_caches(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
-    storage = LocalFS()
-    llm = DummyLlm()
+def test_prompt_assembly_golden():
+    storage = FakeStorage()
+    payload = {
+        "executive_summary": "exec",
+        "kpi_sentences": {
+            "bscore": "bscore sent",
+            "intactness": "intact sent",
+            "fragmentation": "frag sent",
+            "ndvi_trend": "ndvi sent",
+        },
+        "esrs_e4": {
+            "extent_condition": "extent",
+            "pressures": "press",
+            "targets": "targets",
+            "actions": "actions",
+            "financial_effects": "effects",
+        },
+        "flags": [],
+        "numbers": {},
+        "meta": {},
+    }
+    llm = RecordingLlm(payload)
     svc = _service(llm, storage)
 
-    metrics = Path("metrics.csv")
-    timeseries = Path("ts.csv")
-    _write_metrics(storage, metrics)
-    _write_timeseries(storage, timeseries)
+    metrics = _write_metrics(storage, "metrics.csv")
+    timeseries = _write_timeseries(storage, "ts.csv")
 
     req = AiReportRequest(
         aoi_id="a1",
         project_id="p1",
-        metrics_path=str(metrics),
-        timeseries_path=str(timeseries),
+        metrics_path=metrics,
+        timeseries_path=timeseries,
     )
 
+    svc.generate_summary(req)
+    prompts = get_prompts("v1")
+    metrics_csv = pd.read_csv(pd.io.common.BytesIO(storage.files[metrics])).to_csv(
+        index=False
+    ).strip()
+    ts_df = pd.read_csv(pd.io.common.BytesIO(storage.files[timeseries]))
+    ts_df["date"] = pd.to_datetime(ts_df["date"]).dt.to_period("M").astype(str)
+    timeseries_str = "\n".join(
+        f"{r.date},{r.value:.3f}" for r in ts_df.sort_values("date").itertuples()
+    )
+    context = "ecoregion=Tropical, elevation_mean_m=100.0, wdpa_inside=False"
+    user_prompt = prompts.user.format(
+        aoi_id="a1",
+        project_id="p1",
+        window_start="2024-01-01",
+        window_end="2024-12-31",
+        metrics_row=metrics_csv,
+        timeseries=timeseries_str,
+        context=context,
+    )
+    expected_prompt = "\n\n".join([prompts.system, prompts.developer, user_prompt])
+    assert llm.last_prompt == expected_prompt
+
+
+def test_schema_validation_error():
+    storage = FakeStorage()
+    # Missing required kpi_sentences and esrs_e4 blocks
+    invalid_payload = json.dumps({"executive_summary": "hi"})
+    llm = SchemaLlm(invalid_payload)
+    svc = _service(llm, storage)
+
+    metrics = _write_metrics(storage, "metrics.csv")
+    timeseries = _write_timeseries(storage, "ts.csv")
+
+    req = AiReportRequest(
+        aoi_id="a1",
+        project_id="p1",
+        metrics_path=metrics,
+        timeseries_path=timeseries,
+    )
+
+    with pytest.raises(ValidationError):
+        svc.generate_summary(req)
+
+
+def test_generate_summary_caches():
+    storage = FakeStorage()
+    payload = {
+        "executive_summary": "exec",
+        "kpi_sentences": {
+            "bscore": "bscore sent",
+            "intactness": "intact sent",
+            "fragmentation": "frag sent",
+            "ndvi_trend": "ndvi sent",
+        },
+        "esrs_e4": {
+            "extent_condition": "extent",
+            "pressures": "press",
+            "targets": "targets",
+            "actions": "actions",
+            "financial_effects": "effects",
+        },
+        "flags": [],
+        "numbers": {},
+        "meta": {},
+    }
+    llm = RecordingLlm(payload)
+    svc = _service(llm, storage)
+
+    metrics = _write_metrics(storage, "metrics.csv")
+    timeseries = _write_timeseries(storage, "ts.csv")
+
+    req = AiReportRequest(
+        aoi_id="a1",
+        project_id="p1",
+        metrics_path=metrics,
+        timeseries_path=timeseries,
+    )
+
+    initial_writes = storage.writes
     res1 = svc.generate_summary(req)
     assert llm.calls == 1
-    assert res1.uri and Path(res1.uri).exists()
+    assert storage.writes == initial_writes + 1  # cache artifact
     assert res1.summary["executive_summary"] == "exec"
-    assert res1.narrative == "exec"
 
     res2 = svc.generate_summary(req)
     assert llm.calls == 1  # cache hit
+    assert storage.writes == initial_writes + 1
     assert res2.summary == res1.summary
-    assert res2.narrative == res1.narrative
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="requires OpenAI credentials",
+)
+def test_openai_smoke(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    storage = LocalFS()
+    llm = OpenAiLlmClient(seed=0)
+    svc = _service(llm, storage)
+
+    metrics = _write_metrics(storage, str(tmp_path / "metrics.csv"))
+    timeseries = _write_timeseries(storage, str(tmp_path / "ts.csv"))
+
+    req = AiReportRequest(
+        aoi_id="a1",
+        project_id="p1",
+        metrics_path=metrics,
+        timeseries_path=timeseries,
+    )
+
+    res = svc.generate_summary(req)
+    assert "executive_summary" in res.summary
+


### PR DESCRIPTION
## Summary
- exercise ai report service hashing, prompt assembly, schema validation and cache behavior with in-memory fakes
- add environment-guarded OpenAI smoke test
- register `slow` marker for pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a37f3310c8321b5db66cb29f90d4c