### PR TITLE
docs: note AI report dataclass schemas and config defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment variables for VerdeSat
+# Fill in values as needed for local development.
+OPENAI_API_KEY=
+AI_REPORT_MODEL=gpt-4o-mini
+AI_REPORT_SEED=42
+AI_REPORT_PROMPT_VERSION=v1

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ venv/
 .venv/
 .env
 .env.*
+!.env.example
 .ee-andreydara.json
 
 # OS temp files

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -202,6 +202,7 @@ _Generated: 2025-08-11T17:01:49Z_
 ## `verdesat.schemas`
 
 ## `verdesat.schemas.ai_report`
+> Dataclass-based schemas for AI report requests/results.
 **Classes**
 - `MetricsSummary` — Aggregated AOI metrics passed to the language model.
 - `TimeseriesRow` — Single observation from the VI time series.

--- a/docs/ai_report_spec.md
+++ b/docs/ai_report_spec.md
@@ -2,6 +2,9 @@ AI Report Summary Module — Specification (VerdeSat)
 
 Last updated: 2025-08-11
 
+Implementation notes: schemas use dataclasses rather than Pydantic, and
+configuration keys follow snake_case names (ai_report_model, etc.).
+
 0) Purpose & Scope
 
 Generate customer-facing report summaries (ESRS/TNFD-aligned, screening-grade) from pre-computed metrics and VI time series. The module must:
@@ -26,7 +29,7 @@ verdesat/
 │  ├─ llm_openai.py         # OpenAI client adapter (Responses API + Structured Outputs)
 │  └─ prompt_store.py       # Versioned prompt templates
 ├─ schemas/
-│  └─ ai_report.py          # Pydantic models for inputs/outputs
+│  └─ ai_report.py          # Dataclass models for inputs/outputs
 ├─ core/
 │  └─ pipeline.py           # will call AiReportService in Evidence Pack step
 └─ tests/
@@ -73,7 +76,8 @@ wdpa_inside, nearest_pa_name, nearest_pa_distance_km,
 nearest_kba_name, nearest_kba_distance_km,
 area_ha, centroid_lat, centroid_lon, ecoregion, elevation_mean_m, slope_mean_deg
 
-Notes: values absent → NaN allowed. Types validated by Pydantic in schemas/ai_report.py.
+Notes: values absent → NaN allowed. Schemas implemented via dataclasses in
+schemas/ai_report.py; validation occurs in the service layer.
 
 2.2 Time series (CSV/Parquet)
 
@@ -259,7 +263,7 @@ Produce JSON conforming to schema ai_report.v1 only.
 ⸻
 
 11) Config & Secrets
-	•	AI_REPORT_MODEL (default: gpt-4o-mini), AI_REPORT_SEED (default: 42), AI_REPORT_PROMPT_VERSION (default: v1).
+	•	AI_REPORT_MODEL (default: gpt-4o-mini), AI_REPORT_SEED (default: 42), AI_REPORT_PROMPT_VERSION (default: v1) via env vars; ConfigManager keys are ai_report_model, ai_report_seed, ai_report_prompt_version.
 	•	OPENAI_API_KEY via env. No keys in repo.
 	•	Max input sizes: enforce 10 MB per request (Responses API). For larger tables, down-select columns or pre-aggregate.
 

--- a/verdesat/core/config.py
+++ b/verdesat/core/config.py
@@ -60,6 +60,9 @@ class ConfigManager:
     DEFAULT_REPORT_TITLE: str = "VerdeSat Report"
     DEFAULT_MONTHLY_INDEX: str = "ndvi"
     DEFAULT_ANNUAL_INDEX: str = "msavi"
+    DEFAULT_AI_REPORT_MODEL: str = "gpt-4o-mini"
+    DEFAULT_AI_REPORT_PROMPT_VERSION: str = "v1"
+    DEFAULT_AI_REPORT_SEED: int = 42
 
     def __init__(self, config_path=None):
         self.config = {
@@ -68,6 +71,9 @@ class ConfigManager:
             "report_title": self.DEFAULT_REPORT_TITLE,
             "monthly_index": self.DEFAULT_MONTHLY_INDEX,
             "annual_index": self.DEFAULT_ANNUAL_INDEX,
+            "ai_report_model": self.DEFAULT_AI_REPORT_MODEL,
+            "ai_report_prompt_version": self.DEFAULT_AI_REPORT_PROMPT_VERSION,
+            "ai_report_seed": self.DEFAULT_AI_REPORT_SEED,
         }
         self.supported_input_formats = list(self.SUPPORTED_INPUT_FORMATS)
         self.preset_palettes = {k: list(v) for k, v in self.PRESET_PALETTES.items()}


### PR DESCRIPTION
## Summary
- note dataclass-based schemas and config key names in AI report spec and module docs
- add ai_report defaults to ConfigManager and example environment file

## Testing
- `ruff check verdesat/core/config.py`
- `mypy verdesat/core/config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689a3c6089608321b92e218692715960