### PR TITLE
feat: add structured logging for ai reports

### DIFF
--- a/tests/adapters/test_llm_openai.py
+++ b/tests/adapters/test_llm_openai.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
+import logging
+
 import pytest
 from pydantic import BaseModel
 
+import verdesat.adapters.llm_openai as llm_openai
 from verdesat.adapters.llm_openai import OpenAiLlmClient
+from verdesat.core.logger import Logger
 
 
 class _Content:
@@ -19,25 +23,32 @@ class _Output:
 
 
 class _Response:
-    def __init__(self, text: str) -> None:
+    def __init__(self, text: str, usage: Dict[str, int] | None = None) -> None:
         self.output = [_Output(text)]
+        self.usage = usage or {"input_tokens": 1, "output_tokens": 2}
 
 
 class _Responses:
-    def __init__(self, texts: list[str], calls: list[Dict[str, Any]]) -> None:
+    def __init__(
+        self,
+        texts: list[str],
+        calls: list[Dict[str, Any]],
+        usage: Dict[str, int] | None = None,
+    ) -> None:
         self._texts = texts
         self._calls = calls
+        self._usage = usage or {"input_tokens": 1, "output_tokens": 2}
 
     def create(self, **kwargs: Any) -> _Response:
         self._calls.append(kwargs)
         text = self._texts.pop(0)
-        return _Response(text)
+        return _Response(text, self._usage)
 
 
 class FakeOpenAI:
-    def __init__(self, texts: list[str]) -> None:
+    def __init__(self, texts: list[str], usage: Dict[str, int] | None = None) -> None:
         self.calls: list[Dict[str, Any]] = []
-        self.responses = _Responses(texts, self.calls)
+        self.responses = _Responses(texts, self.calls, usage)
 
 
 class OutputModel(BaseModel):
@@ -45,7 +56,11 @@ class OutputModel(BaseModel):
 
 
 def test_generate_passes_deterministic_params() -> None:
-    client = OpenAiLlmClient(client=FakeOpenAI(['{"answer": "ok"}']), seed=99)
+    client = OpenAiLlmClient(
+        client=FakeOpenAI(['{"answer": "ok"}']),
+        seed=99,
+        logger=Logger.get_logger("test"),
+    )
     result = client.generate("hi", response_model=OutputModel, model="gpt-4o-mini")
     assert result == {"answer": "ok"}
     params = client._client.calls[0]  # type: ignore[attr-defined]
@@ -60,7 +75,9 @@ def test_generate_passes_deterministic_params() -> None:
 def test_generate_retries_on_validation_error() -> None:
     texts = ["not json", '{"answer": "ok"}']
     fake = FakeOpenAI(texts)
-    client = OpenAiLlmClient(client=fake, max_retries=1)
+    client = OpenAiLlmClient(
+        client=fake, max_retries=1, logger=Logger.get_logger("test")
+    )
     result = client.generate("hi", response_model=OutputModel, model="gpt-4o-mini")
     assert result == {"answer": "ok"}
     assert len(fake.calls) == 2
@@ -69,6 +86,29 @@ def test_generate_retries_on_validation_error() -> None:
 def test_generate_raises_after_retry() -> None:
     texts = ["not json", "still bad"]
     fake = FakeOpenAI(texts)
-    client = OpenAiLlmClient(client=fake, max_retries=1)
+    client = OpenAiLlmClient(
+        client=fake, max_retries=1, logger=Logger.get_logger("test")
+    )
     with pytest.raises(Exception):
         client.generate("hi", response_model=OutputModel, model="gpt-4o-mini")
+
+
+def test_generate_logs_metrics(caplog, monkeypatch) -> None:
+    fake = FakeOpenAI(
+        ['{"answer": "ok"}'], usage={"input_tokens": 3, "output_tokens": 4}
+    )
+    client = OpenAiLlmClient(client=fake, seed=0, logger=Logger.get_logger("test"))
+
+    times = iter([1.0, 1.1])
+    monkeypatch.setattr(llm_openai.time, "perf_counter", lambda: next(times))
+
+    with caplog.at_level(logging.INFO):
+        client.generate("hi", response_model=OutputModel, model="gpt-4o-mini")
+
+    record = caplog.records[-1]
+    assert record.event == "openai.response"
+    assert record.model == "gpt-4o-mini"
+    assert record.latency_ms == 100.0
+    assert record.input_tokens == 3
+    assert record.output_tokens == 4
+    assert record.retries == 0

--- a/verdesat/core/logger.py
+++ b/verdesat/core/logger.py
@@ -23,6 +23,32 @@ class JSONFormatter(logging.Formatter):
             "name": record.name,
             "message": record.getMessage(),
         }
+        # Include any extra attributes on the LogRecord for structured logging
+        standard = {
+            "name",
+            "msg",
+            "args",
+            "levelname",
+            "levelno",
+            "pathname",
+            "filename",
+            "module",
+            "exc_info",
+            "exc_text",
+            "stack_info",
+            "lineno",
+            "funcName",
+            "created",
+            "msecs",
+            "relativeCreated",
+            "thread",
+            "threadName",
+            "processName",
+            "process",
+            "message",
+        }
+        extras = {k: v for k, v in record.__dict__.items() if k not in standard}
+        record_dict.update(extras)
         return json.dumps(record_dict)
 
 


### PR DESCRIPTION
## Summary
- extend core logger to include extra fields in JSON output
- log model, latency, token counts and retries in OpenAI client
- emit cache hit/miss logs in AiReportService and cover with tests

## Testing
- `ruff check verdesat/core/logger.py verdesat/adapters/llm_openai.py verdesat/services/ai_report.py tests/adapters/test_llm_openai.py tests/services/test_ai_report.py`
- `mypy verdesat/core/logger.py verdesat/adapters/llm_openai.py verdesat/services/ai_report.py tests/adapters/test_llm_openai.py tests/services/test_ai_report.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a405566a88321a0ea1cc40c9495b0