### PR TITLE
feat: add AI report CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,10 @@ verdesat landcover aoi.geojson --year 2024 -o lc_2024.tif
 verdesat bscore-from-geojson aoi.geojson --year 2024 -o metrics.json
 
 # Build a one-page HTML/PDF report
-verdesat report aoi.geojson --index ndvi -o report.html
+verdesat report html aoi.geojson ndvi.csv ndvi.html -d decompositions/ -c chips/ -o report.html
+
+# Generate an AI executive summary
+verdesat report ai --project P1 --aoi A1 --metrics metrics.csv --timeseries ndvi.csv
 ```
 Run `verdesat --help` for the full set of commands.
 

--- a/tests/test_cli_ai_report.py
+++ b/tests/test_cli_ai_report.py
@@ -1,0 +1,86 @@
+import pandas as pd
+from click.testing import CliRunner
+
+from verdesat.core.cli import cli
+
+
+class DummyLlm:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def generate(self, prompt: str, **kwargs):
+        return {
+            "executive_summary": "exec",
+            "kpi_sentences": {
+                "bscore": "b",
+                "intactness": "i",
+                "fragmentation": "f",
+                "ndvi_trend": "n",
+            },
+            "esrs_e4": {
+                "extent_condition": "extent",
+                "pressures": "press",
+                "targets": "targets",
+                "actions": "actions",
+                "financial_effects": "effects",
+            },
+            "flags": [],
+            "numbers": {},
+            "meta": {},
+        }
+
+
+def _write_metrics(path):
+    df = pd.DataFrame(
+        {
+            "aoi_id": ["A1"],
+            "project_id": ["P1"],
+            "method_version": ["0.1"],
+            "window_start": ["2024-01-01"],
+            "window_end": ["2024-12-31"],
+        }
+    )
+    df.to_csv(path, index=False)
+
+
+def _write_timeseries(path):
+    df = pd.DataFrame(
+        {
+            "date": ["2024-01-01"],
+            "metric": ["ndvi_mean"],
+            "value": [0.5],
+            "aoi_id": ["A1"],
+        }
+    )
+    df.to_csv(path, index=False)
+
+
+def test_report_ai_cli(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    metrics = tmp_path / "metrics.csv"
+    timeseries = tmp_path / "ts.csv"
+    _write_metrics(metrics)
+    _write_timeseries(timeseries)
+
+    monkeypatch.setattr(
+        "verdesat.core.cli.OpenAiLlmClient", lambda seed, logger: DummyLlm()
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "report",
+            "ai",
+            "--project",
+            "P1",
+            "--aoi",
+            "A1",
+            "--metrics",
+            str(metrics),
+            "--timeseries",
+            str(timeseries),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "exec" in result.output


### PR DESCRIPTION
## Summary
- add `verdesat report ai` subcommand generating LLM summaries
- document new AI report and HTML report subcommands
- add CLI regression test for AI report

## Testing
- `black verdesat/core/cli.py tests/test_cli_ai_report.py`
- `ruff check verdesat/core/cli.py tests/test_cli_ai_report.py`
- `mypy verdesat/core/cli.py tests/test_cli_ai_report.py`
- `PYTHONPATH=. pytest tests/test_cli_ai_report.py -q`
- `PYTHONPATH=. pytest -q` *(fails: many import errors such as missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_689a509f7cec832192774959e3ed52ed