### PR TITLE
feat: add reporting DTOs and label mapping

### DIFF
--- a/tests/test_reporting_schemas.py
+++ b/tests/test_reporting_schemas.py
@@ -1,0 +1,29 @@
+from dataclasses import is_dataclass
+
+from verdesat.schemas.reporting import (
+    LABELS,
+    AoiContext,
+    MetricsRow,
+    ProjectContext,
+)
+
+
+def test_project_context_defaults():
+    ctx = ProjectContext(project_id="p1", project_name="Demo")
+    assert ctx.owner is None
+    assert ctx.countries_iso3 is None
+    assert is_dataclass(ctx)
+
+
+def test_aoi_context_required_and_defaults():
+    aoi = AoiContext(aoi_id="a1")
+    assert aoi.aoi_name is None
+    assert aoi.tags is None
+    assert is_dataclass(aoi)
+
+
+def test_metrics_row_defaults_and_labels():
+    row = MetricsRow()
+    assert row.ndvi_mean is None
+    assert LABELS["ndvi_mean"] == "NDVI μ"
+    assert "bscore" in LABELS

--- a/verdesat/schemas/reporting.py
+++ b/verdesat/schemas/reporting.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+# Data transfer objects for reporting services. Fields follow the canonical
+# snake_case schema described in ``docs/report_unification.md``. ``LABELS``
+# maps these field names to human-readable captions for templates.
+
+
+@dataclass
+class ProjectContext:
+    """Minimal project metadata used in reports."""
+
+    project_id: str
+    project_name: str
+    owner: str | None = None
+    created_at_utc: str | None = None
+    # Static context (extendable)
+    countries_iso3: List[str] | None = None
+    primary_country_iso3: str | None = None
+    climate_zones: List[str] | None = None
+    ecoregions: List[str] | None = None
+
+
+@dataclass
+class AoiContext:
+    """Static Area of Interest metadata."""
+
+    aoi_id: str
+    aoi_name: str | None = None
+    project_id: str | None = None
+    geometry_path: str | None = None
+    centroid_lon: float | None = None
+    centroid_lat: float | None = None
+    area_ha: float | None = None
+    country_iso3: str | None = None
+    admin1: str | None = None
+    admin2: str | None = None
+    biome: str | None = None
+    ecoregion: str | None = None
+    climate_zone: str | None = None
+    tags: Dict[str, str] | None = None
+
+
+@dataclass
+class MetricsRow:
+    """Snapshot metrics for a single AOI."""
+
+    # Vegetation
+    ndvi_mean: float | None = None
+    ndvi_slope: float | None = None  # per year
+    ndvi_delta: float | None = None  # last_year - prev_year
+    msavi_mean: float | None = None
+    # Biodiversity proxies
+    intactness_pct: float | None = None
+    frag_norm: float | None = None
+    shannon: float | None = None
+    # Composite
+    bscore: float | None = None  # 0..100
+    bscore_band: str | None = None  # "low|moderate|high"
+    # Validity
+    valid_obs_pct: float | None = None
+    # Sensitivity context
+    inside_pa: bool | None = None
+    nearest_pa_name: str | None = None
+    nearest_pa_distance_km: float | None = None
+    nearest_kba_name: str | None = None
+    nearest_kba_distance_km: float | None = None
+    # Time window used
+    window_start: str | None = None
+    window_end: str | None = None
+
+
+LABELS: Dict[str, str] = {
+    "ndvi_mean": "NDVI μ",
+    "ndvi_slope": "NDVI slope/yr",
+    "ndvi_delta": "ΔNDVI (YoY)",
+    "msavi_mean": "MSAVI μ",
+    "intactness_pct": "Intactness %",
+    "frag_norm": "Frag‑Norm",
+    "shannon": "Shannon H′",
+    "msa": "MSA",
+    "bscore": "B‑Score",
+    "bscore_band": "B‑Score band",
+    "valid_obs_pct": "% valid obs",
+}
+
+__all__ = [
+    "ProjectContext",
+    "AoiContext",
+    "MetricsRow",
+    "LABELS",
+]


### PR DESCRIPTION
## Summary
- add ProjectContext, AoiContext and MetricsRow dataclasses for reporting
- expose LABELS mapping for human-friendly field names
- cover DTO defaults and label mapping with tests

## Testing
- `ruff check verdesat/schemas/reporting.py tests/test_reporting_schemas.py`
- `black verdesat/schemas/reporting.py tests/test_reporting_schemas.py`
- `mypy verdesat/schemas/reporting.py tests/test_reporting_schemas.py`
- `PYTHONPATH=. pytest tests/test_reporting_schemas.py --noconftest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b746130ac832185770aa0a5c5a699