### PR TITLE
refactor timeseries emitters to TimeseriesLong

### DIFF
--- a/tests/test_timeseries.py
+++ b/tests/test_timeseries.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from verdesat.analytics.timeseries import TimeSeries
+from verdesat.analytics.timeseries import TimeSeries, decomp_to_long
 
 
 def test_fill_gaps_and_to_csv(tmp_path):
@@ -37,3 +37,39 @@ def test_decompose():
     res = ts.decompose(period=12)
     assert 1 in res
     assert res[1].trend is not None
+
+
+def test_to_long_and_decomp_to_long():
+    df = pd.DataFrame(
+        {
+            "id": [1, 1],
+            "date": ["2020-01-01", "2020-02-01"],
+            "mean_ndvi": [0.1, 0.2],
+        }
+    )
+    ts = TimeSeries.from_dataframe(df, index="ndvi")
+    long_df = ts.to_long(freq="monthly", source="S2")
+    assert set(long_df.columns) == {
+        "date",
+        "var",
+        "stat",
+        "value",
+        "aoi_id",
+        "freq",
+        "source",
+    }
+    assert (long_df["stat"].unique() == ["raw"]).all()
+
+    decomp_df = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2020-01-01", "2020-02-01"]),
+            "observed": [0.1, 0.2],
+            "trend": [0.1, 0.2],
+            "seasonal": [0.0, 0.0],
+            "resid": [0.0, 0.0],
+        }
+    )
+    long_decomp = decomp_to_long(
+        decomp_df, aoi_id="1", var="ndvi", freq="monthly", source="S2"
+    )
+    assert set(long_decomp["stat"]) == {"raw", "trend", "seasonal", "anomaly"}


### PR DESCRIPTION
## Summary
- add `to_long` and `decomp_to_long` helpers to convert spectral time series and decomposition outputs into the unified TimeseriesLong schema
- refactor pipeline and CLI to emit TimeseriesLong instead of wide CSVs
- cover conversion helpers with unit tests

## Testing
- `black verdesat/analytics/timeseries.py verdesat/core/pipeline.py verdesat/core/cli.py tests/test_timeseries.py`
- `ruff check verdesat/analytics/timeseries.py verdesat/core/pipeline.py verdesat/core/cli.py tests/test_timeseries.py`
- `mypy verdesat/analytics/timeseries.py verdesat/core/pipeline.py verdesat/core/cli.py tests/test_timeseries.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc00c37e08321ac238f3446af8ef3