### PR TITLE
feat: add msa and p-value to metrics

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -297,11 +297,8 @@ _Generated: 2025-08-12T17:03:51Z_
 - `msavi_bar_chart_all` — Render annual mean MSAVI for all AOIs as grouped bars.
 
 ## `verdesat.webapp.components.kpi_cards`
-**Classes**
-- `Metrics` — Container for biodiversity metrics.
-
 **Functions**
-- `aggregate_metrics` — Return mean values for ``df`` as a :class:`Metrics` instance.
+- `aggregate_metrics` — Return mean values for ``df`` as a :class:`MetricsRow` instance.
 - `display_metrics` — Render KPI cards for the provided metrics.
 - `bscore_gauge` — Display a gauge chart for the B-Score, with risk band and formula explanation.
 

--- a/docs/report_unification.md
+++ b/docs/report_unification.md
@@ -63,11 +63,13 @@ class MetricsRow:
     ndvi_mean: float | None = None
     ndvi_slope: float | None = None       # per year
     ndvi_delta: float | None = None       # last_year - prev_year
+    ndvi_p_value: float | None = None     # Mann-Kendall p-value
     msavi_mean: float | None = None
     # Biodiversity proxies
     intactness_pct: float | None = None
     frag_norm: float | None = None
     shannon: float | None = None
+    msa: float | None = None
     # Composite
     bscore: float | None = None           # 0..100
     bscore_band: str | None = None        # "low|moderate|high"
@@ -121,6 +123,7 @@ LABELS = {
   "ndvi_mean": "NDVI μ",
   "ndvi_slope": "NDVI slope/yr",
   "ndvi_delta": "ΔNDVI (YoY)",
+  "ndvi_p_value": "NDVI p-value",
   "msavi_mean": "MSAVI μ",
   "intactness_pct": "Intactness %",
   "frag_norm": "Frag‑Norm",

--- a/docs/reporting_templates.md
+++ b/docs/reporting_templates.md
@@ -48,8 +48,10 @@ This file contains **production-ready HTML/Jinja2 templates** and **print CSS** 
         <div class="kpi-strip">
           <div class="kpi"><span>Intactness</span><strong>{{ intactness_pct|round(1) }}%</strong></div>
           <div class="kpi"><span>Frag‑Norm</span><strong>{{ frag_norm|round(2) }}</strong></div>
+          <div class="kpi"><span>MSA</span><strong>{{ msa|round(2) }}</strong></div>
           <div class="kpi"><span>NDVI μ</span><strong>{{ ndvi_mean|round(3) }}</strong></div>
           <div class="kpi"><span>NDVI slope/yr</span><strong>{{ ndvi_slope|round(3) }}</strong></div>
+          <div class="kpi"><span>NDVI p-value</span><strong>{{ ndvi_p_value|round(3) }}</strong></div>
           <div class="kpi"><span>ΔNDVI YoY</span><strong>{{ ndvi_delta|round(3) }}</strong></div>
           <div class="kpi"><span>% valid obs</span><strong>{{ valid_obs_pct|round(0) }}%</strong></div>
         </div>
@@ -239,7 +241,7 @@ h3 { font-size: 12pt; margin: 10px 0 4px; }
 .summary-grid { display: grid; grid-template-columns: 1.1fr 1.5fr; grid-template-rows: auto auto; gap: 10px; margin-top: 8px; }
 .summary-grid .panel { border: 1px solid #e2e8f0; border-radius: 8px; padding: 10px; }
 .summary-grid .map img { width: 100%; border-radius: 8px; border: 1px solid #e2e8f0; }
-.kpi-strip { display: grid; grid-template-columns: repeat(6, 1fr); gap: 6px; }
+.kpi-strip { display: grid; grid-template-columns: repeat(8, 1fr); gap: 6px; }
 .kpi { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; padding: 6px 8px; font-size: 10.5pt; }
 .kpi span { color: #475569; display: block; font-size: 9.5pt; }
 
@@ -289,7 +291,8 @@ context = dict(
     report_hash="{{computed_sha256}}",
     bscore=54, bscore_band="Moderate", bscore_band_label="Moderate risk",
     weights=dict(intactness=0.4, shannon=0.3, fragmentation=0.3),
-    intactness_pct=62.1, frag_norm=0.44, ndvi_mean=0.72, ndvi_slope=0.012, ndvi_delta=0.021,
+    intactness_pct=62.1, frag_norm=0.44, msa=0.78,
+    ndvi_mean=0.72, ndvi_slope=0.012, ndvi_p_value=0.045, ndvi_delta=0.021,
     valid_obs_pct=87.0,
     acquisition_from="2024-01-01", acquisition_to="2024-12-31",
     executive_summary="Moderate condition; fragmentation elevated; greenness improving (0.012/yr).",

--- a/tests/webapp/test_kpi_cards.py
+++ b/tests/webapp/test_kpi_cards.py
@@ -7,44 +7,44 @@ from verdesat.webapp.components.kpi_cards import aggregate_metrics
 def test_aggregate_metrics_computes_means():
     df = pd.DataFrame(
         {
-            "intactness": [0.2, 0.4],
+            "intactness_pct": [0.2, 0.4],
             "shannon": [0.3, 0.5],
-            "fragmentation": [0.1, 0.3],
-            "msa": [0.7, 0.9],
+            "frag_norm": [0.1, 0.3],
             "ndvi_mean": [0.1, 0.2],
-            "ndvi_std": [0.01, 0.03],
             "ndvi_slope": [0.05, -0.05],
             "ndvi_delta": [0.02, 0.04],
             "ndvi_p_value": [0.1, 0.2],
-            "ndvi_pct_fill": [80.0, 90.0],
+            "valid_obs_pct": [20.0, 10.0],
             "msavi_mean": [0.6, 0.8],
-            "msavi_std": [0.02, 0.04],
             "bscore": [50.0, 70.0],
+            "msa": [0.5, 0.7],
         }
     )
     metrics = aggregate_metrics(df)
-    assert metrics.intactness == pytest.approx(0.3)
-    assert metrics.msa == pytest.approx(0.8)
+    assert metrics.intactness_pct == pytest.approx(0.3)
+    assert metrics.frag_norm == pytest.approx(0.2)
     assert metrics.bscore == pytest.approx(60.0)
+    assert metrics.bscore_band == "moderate"
+    assert metrics.valid_obs_pct == pytest.approx(15.0)
+    assert metrics.msa == pytest.approx(0.6)
+    assert metrics.ndvi_p_value == pytest.approx(0.15)
 
 
-def test_aggregate_metrics_handles_missing_msa():
+def test_aggregate_metrics_handles_missing_fill():
     df = pd.DataFrame(
         {
-            "intactness": [0.2, 0.4],
+            "intactness_pct": [0.2, 0.4],
             "shannon": [0.3, 0.5],
-            "fragmentation": [0.1, 0.3],
-            # no MSA column
+            "frag_norm": [0.1, 0.3],
             "ndvi_mean": [0.1, 0.2],
-            "ndvi_std": [0.01, 0.03],
             "ndvi_slope": [0.05, -0.05],
             "ndvi_delta": [0.02, 0.04],
             "ndvi_p_value": [0.1, 0.2],
-            "ndvi_pct_fill": [80.0, 90.0],
+            # no valid_obs_pct column
             "msavi_mean": [0.6, 0.8],
-            "msavi_std": [0.02, 0.04],
             "bscore": [50.0, 70.0],
+            "msa": [0.5, 0.7],
         }
     )
     metrics = aggregate_metrics(df)
-    assert metrics.msa == 0.0  # default when missing
+    assert metrics.valid_obs_pct is None

--- a/tests/webapp/test_project_compute_service.py
+++ b/tests/webapp/test_project_compute_service.py
@@ -79,7 +79,7 @@ def test_compute_invokes_chip_service_and_aggregates(monkeypatch):
                 "ndvi_delta": 0.0,
                 "ndvi_p_value": 0.5,
                 "ndvi_peak": "Jan",
-                "ndvi_pct_fill": 0.0,
+                "valid_obs_pct": 100.0,
             },
             pd.DataFrame(
                 {
@@ -154,7 +154,7 @@ def test_compute_uses_cache(monkeypatch):
                 "ndvi_delta": [0.0],
                 "ndvi_p_value": [0.5],
                 "ndvi_peak": ["Jan"],
-                "ndvi_pct_fill": [0.0],
+                "valid_obs_pct": [100.0],
                 "msavi_mean": [2.0],
                 "msavi_median": [2.0],
                 "msavi_min": [2.0],
@@ -178,7 +178,7 @@ def test_compute_uses_cache(monkeypatch):
                 "ndvi_delta": 0.0,
                 "ndvi_p_value": 0.5,
                 "ndvi_peak": "Jan",
-                "ndvi_pct_fill": 0.0,
+                "valid_obs_pct": 100.0,
                 "msavi_mean": 2.0,
                 "msavi_median": 2.0,
                 "msavi_min": 2.0,
@@ -235,7 +235,7 @@ def test_compute_recomputes_legacy_cache(monkeypatch):
                 "ndvi_delta": 0.0,
                 "ndvi_p_value": 0.5,
                 "ndvi_peak": "Jan",
-                "ndvi_pct_fill": 0.0,
+                "valid_obs_pct": 100.0,
             },
             pd.DataFrame(
                 {
@@ -275,7 +275,7 @@ def test_compute_recomputes_legacy_cache(monkeypatch):
         "ndvi_delta",
         "ndvi_p_value",
         "ndvi_peak",
-        "ndvi_pct_fill",
+        "valid_obs_pct",
         "msavi_mean",
         "msavi_median",
         "msavi_min",
@@ -344,7 +344,7 @@ def test_ndvi_stats_returns_required_metrics(monkeypatch):
         "ndvi_delta",
         "ndvi_p_value",
         "ndvi_peak",
-        "ndvi_pct_fill",
+        "valid_obs_pct",
     }
     assert list(df_out.columns) == ["date", "observed", "trend", "seasonal"]
 
@@ -448,7 +448,7 @@ def test_ndvi_stats_handles_missing_decomposition(monkeypatch):
         "ndvi_delta",
         "ndvi_p_value",
         "ndvi_peak",
-        "ndvi_pct_fill",
+        "valid_obs_pct",
     } == set(stats.keys())
     assert list(df_out.columns) == ["date", "observed", "trend", "seasonal"]
 

--- a/verdesat/schemas/reporting.py
+++ b/verdesat/schemas/reporting.py
@@ -51,11 +51,13 @@ class MetricsRow:
     ndvi_mean: float | None = None
     ndvi_slope: float | None = None  # per year
     ndvi_delta: float | None = None  # last_year - prev_year
+    ndvi_p_value: float | None = None
     msavi_mean: float | None = None
     # Biodiversity proxies
     intactness_pct: float | None = None
     frag_norm: float | None = None
     shannon: float | None = None
+    msa: float | None = None
     # Composite
     bscore: float | None = None  # 0..100
     bscore_band: str | None = None  # "low|moderate|high"
@@ -76,6 +78,7 @@ LABELS: Dict[str, str] = {
     "ndvi_mean": "NDVI μ",
     "ndvi_slope": "NDVI slope/yr",
     "ndvi_delta": "ΔNDVI (YoY)",
+    "ndvi_p_value": "NDVI p-value",
     "msavi_mean": "MSAVI μ",
     "intactness_pct": "Intactness %",
     "frag_norm": "Frag‑Norm",

--- a/verdesat/webapp/app.py
+++ b/verdesat/webapp/app.py
@@ -24,7 +24,6 @@ from verdesat.webapp.components.charts import (
     ndvi_component_chart,
 )
 from verdesat.webapp.components.kpi_cards import (
-    Metrics,
     aggregate_metrics,
     bscore_gauge,
     display_metrics,

--- a/verdesat/webapp/services/project_compute.py
+++ b/verdesat/webapp/services/project_compute.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Project-level computation of metrics for the web application."""
+
+from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -200,7 +200,7 @@ def _stats_row_to_dict(row: pd.Series, index: str) -> dict[str, float | str]:
                 f"{index}_peak": (
                     row["Peak Month"] if pd.notna(row["Peak Month"]) else ""
                 ),
-                f"{index}_pct_fill": float(row["% Gapfilled"]),
+                "valid_obs_pct": 100.0 - float(row["% Gapfilled"]),
             }
         )
     return stats
@@ -385,7 +385,7 @@ class ProjectComputeService:
                     "ndvi_delta",
                     "ndvi_p_value",
                     "ndvi_peak",
-                    "ndvi_pct_fill",
+                    "valid_obs_pct",
                     "msavi_mean",
                     "msavi_median",
                     "msavi_min",


### PR DESCRIPTION
## Summary
- extend `MetricsRow` with `msa` and `ndvi_p_value` fields and labels
- drop legacy KPI column mapping and surface MSA and NDVI p-value in dashboard cards
- emit `valid_obs_pct` during project compute and update docs and templates for new metrics

## Testing
- `ruff check verdesat/schemas/reporting.py verdesat/webapp/components/kpi_cards.py verdesat/webapp/services/project_compute.py tests/webapp/test_kpi_cards.py tests/webapp/test_project_compute_service.py`
- `black verdesat/schemas/reporting.py verdesat/webapp/components/kpi_cards.py verdesat/webapp/services/project_compute.py tests/webapp/test_kpi_cards.py tests/webapp/test_project_compute_service.py`
- `mypy verdesat/schemas/reporting.py verdesat/webapp/components/kpi_cards.py verdesat/webapp/services/project_compute.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_689bce139fbc8321838f5fdbccb68bbc