### PR TITLE
feat(webapp): add evidence pack bridge

### DIFF
--- a/docs/report_unification.md
+++ b/docs/report_unification.md
@@ -8,7 +8,7 @@
 
 ## 1) Decisions (non‑negotiable)
 - **Single render engine:** HTML/Jinja2 → **WeasyPrint PDF**. (ReportLab remains an optional fallback only.)
-- **One pack format:** **Evidence Pack (AOI)** and **Project Pack** as **ZIPs** with `report.pdf`, `metrics.csv`, `lineage.json`, and a `figures/` directory.
+- **One pack format:** **Evidence Pack (AOI)** and **Project Pack** as **ZIPs** with `report.pdf`, `metrics.csv`, `lineage.json`, `aoi.geojson`, an optional `ai_summary.json`, and a `figures/` directory.
 - **Canonical schema:** all inputs to the renderer use **snake_case**.
 - **Label mapping:** templates map `snake_case → UI label` for human‑readable captions.
 - **Storage abstraction:** use **StorageAdapter** (LocalFS or R2) selected by config.

--- a/docs/report_unification.md
+++ b/docs/report_unification.md
@@ -286,5 +286,5 @@ verdesat pack project \
 - [x] Refactor timeseries/decomposition emitters to **TimeseriesLong**.
 - [x] Refactor KPI builder to output **MetricsRow**.
  - [x] Implement CLI `verdesat pack aoi|project`.
-- [ ] Implement Web bridge and button.
+ - [x] Implement Web bridge and button.
 - [ ] Remove/deprecate legacy exporters.

--- a/tests/webapp/test_reporting_bridge.py
+++ b/tests/webapp/test_reporting_bridge.py
@@ -63,3 +63,53 @@ def test_build_evidence_pack(monkeypatch):
     assert captured["include_ai"] is True
     assert captured["ai_service"] == "svc"
     assert captured["ai_request"] == {"x": 1}
+
+
+def test_build_evidence_pack_defaults(monkeypatch):
+    """Include AI with no service/request uses safe defaults."""
+
+    aoi = AOI(
+        geometry=Polygon([(0, 0), (0, 1), (1, 1), (1, 0)]),
+        static_props={"id": "1", "area_m2": 10_000},
+    )
+    project = Project(name="Demo", customer="X", aois=[aoi], config=ConfigManager())
+
+    metrics_df = pd.DataFrame(
+        [{"id": "1", "ndvi_mean": 0.2, "bscore": 50.0, "bscore_band": "moderate"}]
+    )
+    ndvi_df = pd.DataFrame(
+        {
+            "id": ["1"],
+            "date": pd.to_datetime(["2024-01-01"]),
+            "observed": [0.2],
+            "trend": [0.1],
+            "seasonal": [0.0],
+        }
+    )
+    msavi_df = pd.DataFrame(
+        {"id": ["1"], "date": pd.to_datetime(["2024-01-01"]), "mean_msavi": [0.3]}
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_build(**kwargs):
+        captured.update(kwargs)
+        return PackResult(uri="u", url=None, sha256="0" * 64, bytesize=1)
+
+    monkeypatch.setattr(
+        "verdesat.webapp.services.reporting_bridge.build_aoi_evidence_pack",
+        fake_build,
+    )
+
+    build_evidence_pack(
+        metrics_df,
+        ndvi_df,
+        msavi_df,
+        project,
+        "1",
+        include_ai=True,
+    )
+
+    assert captured["include_ai"] is True
+    assert captured["ai_service"] is not None
+    assert captured["ai_request"] == {"aoi_id": "1"}

--- a/tests/webapp/test_reporting_bridge.py
+++ b/tests/webapp/test_reporting_bridge.py
@@ -5,6 +5,8 @@ from typing import Any
 from verdesat.core.config import ConfigManager
 from verdesat.geo.aoi import AOI
 from verdesat.project.project import Project
+from verdesat.services.ai_report import AiReportService
+from verdesat.schemas.ai_report import AiReportRequest
 from verdesat.services.reporting import PackResult
 from verdesat.webapp.services.reporting_bridge import build_evidence_pack
 
@@ -66,7 +68,7 @@ def test_build_evidence_pack(monkeypatch):
 
 
 def test_build_evidence_pack_defaults(monkeypatch):
-    """Include AI with no service/request uses safe defaults."""
+    """Include AI with no service/request sets up service and request."""
 
     aoi = AOI(
         geometry=Polygon([(0, 0), (0, 1), (1, 1), (1, 0)]),
@@ -101,6 +103,7 @@ def test_build_evidence_pack_defaults(monkeypatch):
         fake_build,
     )
 
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
     build_evidence_pack(
         metrics_df,
         ndvi_df,
@@ -111,5 +114,6 @@ def test_build_evidence_pack_defaults(monkeypatch):
     )
 
     assert captured["include_ai"] is True
-    assert captured["ai_service"] is not None
-    assert captured["ai_request"] == {"aoi_id": "1"}
+    assert isinstance(captured["ai_service"], AiReportService)
+    assert isinstance(captured["ai_request"], AiReportRequest)
+    assert captured["ai_request"].aoi_id == "1"

--- a/tests/webapp/test_reporting_bridge.py
+++ b/tests/webapp/test_reporting_bridge.py
@@ -96,6 +96,20 @@ def test_build_evidence_pack_defaults(monkeypatch):
 
     def fake_build(**kwargs):
         captured.update(kwargs)
+        ai_req = kwargs.get("ai_request")
+        assert ai_req is not None
+        metrics_df = pd.read_csv(ai_req.metrics_path)
+        required = {
+            "aoi_id",
+            "project_id",
+            "method_version",
+            "window_start",
+            "window_end",
+        }
+        assert required <= set(metrics_df.columns)
+        ts_df = pd.read_csv(ai_req.timeseries_path)
+        assert {"date", "metric", "value", "aoi_id"} <= set(ts_df.columns)
+        assert "ndvi_mean" in ts_df["metric"].values
         return PackResult(uri="u", url=None, sha256="0" * 64, bytesize=1)
 
     monkeypatch.setattr(

--- a/tests/webapp/test_reporting_bridge.py
+++ b/tests/webapp/test_reporting_bridge.py
@@ -1,0 +1,52 @@
+import pandas as pd
+from shapely.geometry import Polygon
+from typing import Any
+
+from verdesat.core.config import ConfigManager
+from verdesat.geo.aoi import AOI
+from verdesat.project.project import Project
+from verdesat.services.reporting import PackResult
+from verdesat.webapp.services.reporting_bridge import build_evidence_pack
+
+
+def test_build_evidence_pack(monkeypatch):
+    aoi = AOI(
+        geometry=Polygon([(0, 0), (0, 1), (1, 1), (1, 0)]),
+        static_props={"id": "1", "area_m2": 10_000},
+    )
+    project = Project(name="Demo", customer="X", aois=[aoi], config=ConfigManager())
+
+    metrics_df = pd.DataFrame(
+        [{"id": "1", "ndvi_mean": 0.2, "bscore": 50.0, "bscore_band": "moderate"}]
+    )
+    ndvi_df = pd.DataFrame(
+        {
+            "id": ["1"],
+            "date": pd.to_datetime(["2024-01-01"]),
+            "observed": [0.2],
+            "trend": [0.1],
+            "seasonal": [0.0],
+        }
+    )
+    msavi_df = pd.DataFrame(
+        {"id": ["1"], "date": pd.to_datetime(["2024-01-01"]), "mean_msavi": [0.3]}
+    )
+
+    captured: dict[str, Any] = {}
+
+    def fake_build(**kwargs):
+        captured.update(kwargs)
+        return PackResult(
+            uri="u", url="http://example.com", sha256="0" * 64, bytesize=1
+        )
+
+    monkeypatch.setattr(
+        "verdesat.webapp.services.reporting_bridge.build_aoi_evidence_pack",
+        fake_build,
+    )
+
+    result = build_evidence_pack(metrics_df, ndvi_df, msavi_df, project, "1")
+
+    assert isinstance(result, PackResult)
+    assert captured["aoi"].aoi_id == "1"
+    assert set(captured["ts_long"]["var"]) == {"ndvi", "msavi"}

--- a/tests/webapp/test_reporting_bridge.py
+++ b/tests/webapp/test_reporting_bridge.py
@@ -45,8 +45,21 @@ def test_build_evidence_pack(monkeypatch):
         fake_build,
     )
 
-    result = build_evidence_pack(metrics_df, ndvi_df, msavi_df, project, "1")
+    result = build_evidence_pack(
+        metrics_df,
+        ndvi_df,
+        msavi_df,
+        project,
+        "1",
+        include_ai=True,
+        ai_service="svc",
+        ai_request={"x": 1},
+    )
 
     assert isinstance(result, PackResult)
     assert captured["aoi"].aoi_id == "1"
+    assert captured["aoi"].geometry_path is not None
     assert set(captured["ts_long"]["var"]) == {"ndvi", "msavi"}
+    assert captured["include_ai"] is True
+    assert captured["ai_service"] == "svc"
+    assert captured["ai_request"] == {"x": 1}

--- a/verdesat/services/reporting.py
+++ b/verdesat/services/reporting.py
@@ -66,6 +66,7 @@ def _write_pack(
     storage: StorageAdapter,
     path_parts: tuple[str, ...],
     ai_summary: dict | None = None,
+    aoi_geojson: bytes | None = None,
 ) -> PackResult:
     """Compose ZIP artefact and persist it using *storage*."""
 
@@ -81,6 +82,8 @@ def _write_pack(
                 "ai_summary.json",
                 json.dumps(ai_summary, indent=2).encode("utf-8"),
             )
+        if aoi_geojson is not None:
+            zf.writestr("aoi.geojson", aoi_geojson)
 
     data = buf.getvalue()
     sha = hashlib.sha256(data).hexdigest()
@@ -119,6 +122,9 @@ def build_aoi_evidence_pack(
 
     map_png = make_map_png(aoi)
     ts_png = make_timeseries_png(ts_long)
+    aoi_geojson: bytes | None = None
+    if aoi.geometry_path and Path(aoi.geometry_path).exists():
+        aoi_geojson = Path(aoi.geometry_path).read_bytes()
 
     ai_summary: dict[str, Any] | None = None
     narrative = ""
@@ -198,6 +204,7 @@ def build_aoi_evidence_pack(
         storage=storage,
         path_parts=path,
         ai_summary=ai_summary,
+        aoi_geojson=aoi_geojson,
     )
 
 

--- a/verdesat/webapp/app.py
+++ b/verdesat/webapp/app.py
@@ -153,8 +153,16 @@ def report_controls(
         return
 
     sel = st.selectbox("AOI for evidence pack", aoi_ids)
+    include_ai = st.checkbox("Include AI summary")
     if st.button("Build AOI evidence pack"):
-        result = build_evidence_pack(metrics_df, ndvi_df, msavi_df, project, sel)
+        result = build_evidence_pack(
+            metrics_df,
+            ndvi_df,
+            msavi_df,
+            project,
+            sel,
+            include_ai=include_ai,
+        )
         st.session_state["pack_url"] = result.url
     pack_url = st.session_state.get("pack_url")
     if pack_url:

--- a/verdesat/webapp/services/reporting_bridge.py
+++ b/verdesat/webapp/services/reporting_bridge.py
@@ -105,14 +105,16 @@ def build_evidence_pack(
             }
         ],
     }
-    if include_ai and ai_service is None:
-        ai_service = SimpleNamespace(
-            generate_summary=lambda _req: SimpleNamespace(
-                narrative="AI summary unavailable",
-                summary={"status": "unavailable"},
+    if include_ai:
+        if ai_service is None:
+            ai_service = SimpleNamespace(
+                generate_summary=lambda _req: SimpleNamespace(
+                    narrative="AI summary unavailable",
+                    summary={"status": "unavailable"},
+                )
             )
-        )
-        ai_request = {}
+        if ai_request is None:
+            ai_request = {"aoi_id": str(aoi_id)}
 
     result = build_aoi_evidence_pack(
         aoi=aoi_ctx,

--- a/verdesat/webapp/services/reporting_bridge.py
+++ b/verdesat/webapp/services/reporting_bridge.py
@@ -1,0 +1,104 @@
+"""Streamlit bridge for unified report generation."""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from typing import Any
+
+import pandas as pd
+
+from verdesat.analytics.timeseries import decomp_to_long
+from verdesat.core.storage import LocalFS, StorageAdapter
+from verdesat.project.project import Project
+from verdesat.schemas.reporting import AoiContext, MetricsRow, ProjectContext
+from verdesat.services.reporting import PackResult, build_aoi_evidence_pack
+
+
+def build_evidence_pack(
+    metrics_df: pd.DataFrame,
+    ndvi_df: pd.DataFrame,
+    msavi_df: pd.DataFrame,
+    project: Project,
+    aoi_id: str,
+    *,
+    storage: StorageAdapter | None = None,
+) -> PackResult:
+    """Generate an evidence pack for ``aoi_id`` using current app state."""
+
+    storage = storage or project.storage or LocalFS()
+    id_col = project.config.get("id_col", "id")
+
+    aoi = next(
+        (a for a in project.aois if str(a.static_props.get(id_col)) == str(aoi_id)),
+        None,
+    )
+    if aoi is None:
+        raise ValueError(f"AOI {aoi_id} not found in project")
+
+    project_ctx = ProjectContext(
+        project_id=project.name,
+        project_name=project.name,
+    )
+
+    centroid = aoi.geometry.centroid
+    area_m2 = aoi.static_props.get("area_m2")
+    aoi_ctx = AoiContext(
+        aoi_id=str(aoi_id),
+        aoi_name=aoi.static_props.get("name"),
+        project_id=project_ctx.project_id,
+        centroid_lon=float(centroid.x),
+        centroid_lat=float(centroid.y),
+        area_ha=(float(area_m2) / 10_000.0) if area_m2 is not None else None,
+    )
+
+    row = metrics_df[metrics_df[id_col].astype(str) == str(aoi_id)].iloc[0].to_dict()
+    field_names = {f.name for f in fields(MetricsRow)}
+    data = {k: row.get(k) for k in field_names if k in row}
+    metrics_row = MetricsRow(**data)
+
+    ndvi_single = ndvi_df[ndvi_df["id"].astype(str) == str(aoi_id)][
+        ["date", "observed", "trend", "seasonal"]
+    ].copy()
+    ndvi_single["resid"] = float("nan")
+    ndvi_long = decomp_to_long(
+        ndvi_single,
+        aoi_id=str(aoi_id),
+        var="ndvi",
+        freq="monthly",
+        source="S2",
+    )
+
+    msavi_single = msavi_df[msavi_df["id"].astype(str) == str(aoi_id)][
+        ["date", "mean_msavi"]
+    ].rename(columns={"mean_msavi": "value"})
+    msavi_long = msavi_single.assign(
+        var="msavi",
+        stat="raw",
+        aoi_id=str(aoi_id),
+        freq="monthly",
+        source="S2",
+    )[["date", "var", "stat", "value", "aoi_id", "freq", "source"]]
+
+    ts_long = pd.concat([ndvi_long, msavi_long], ignore_index=True)
+
+    lineage: dict[str, Any] = {
+        "method_version": "0.2.0",
+        "sources": [
+            {
+                "name": "Sentinel-2 L2A",
+                "version": "v2024",
+                "resolution": "10 m",
+                "date_range": "2017–present",
+                "notes": "NDVI/MSAVI composites",
+            }
+        ],
+    }
+
+    return build_aoi_evidence_pack(
+        aoi=aoi_ctx,
+        project=project_ctx,
+        metrics=metrics_row,
+        ts_long=ts_long,
+        lineage=lineage,
+        storage=storage,
+    )


### PR DESCRIPTION
## Summary
- add reporting_bridge service to convert dashboard state into Pack DTOs
- expose evidence pack download button in Streamlit app
- document completion of web bridge task and add bridge unit test

## Testing
- `pre-commit run --files docs/report_unification.md verdesat/webapp/services/reporting_bridge.py verdesat/webapp/app.py tests/webapp/test_reporting_bridge.py` *(fails: .pre-commit-config.yaml is not a file)*
- `python -m pytest -q` *(fails: 22 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689fb0a44ca88321972e74f926292de5